### PR TITLE
Update tests with new OpenAPI services

### DIFF
--- a/src/apis/AlbumsApi.test.ts
+++ b/src/apis/AlbumsApi.test.ts
@@ -1,122 +1,98 @@
-import { type MockedClass } from 'vitest';
+import { type SpyInstance } from 'vitest';
 
 import {
   albumFixture,
   getAlbumTracksFixture,
   getAlbumsFixture,
 } from '../fixtures';
-import { Http } from '../helpers/Http';
+import { AlbumsService } from '../openapi/services/AlbumsService';
 
 import { AlbumsApi } from './AlbumsApi';
 
-vi.mock('../helpers/Http');
-
-const HttpMock = Http as MockedClass<typeof Http>;
-
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-function setup() {
-  const httpMock = new HttpMock('token');
-  const albums = new AlbumsApi();
-
-  return { httpMock, albums };
-}
+const albums = new AlbumsApi();
 
 describe('AlbumsApi', () => {
-  beforeEach(() => {
+  afterEach(() => {
     vi.resetAllMocks();
   });
 
   describe('getAlbum', () => {
+    let getAnAlbumSpy: SpyInstance;
     beforeEach(() => {
-      HttpMock.prototype.get.mockResolvedValue(albumFixture);
+      getAnAlbumSpy = vi
+        .spyOn(AlbumsService, 'getAnAlbum')
+        .mockResolvedValue(albumFixture);
     });
 
-    it.todo('should get an album (without options)', async () => {
-      const { httpMock, albums } = setup();
-
+    it('should get an album (without options)', async () => {
       const response = await albums.getAlbum('foo');
 
       expect(response).toEqual(albumFixture);
-      expect(httpMock.get).toHaveBeenCalledWith('/albums/foo', undefined);
+      expect(getAnAlbumSpy).toHaveBeenCalledWith('foo', undefined);
     });
 
-    it.todo('should get an album (with options)', async () => {
-      const { httpMock, albums } = setup();
-
+    it('should get an album (with options)', async () => {
       const response = await albums.getAlbum('foo', { market: 'bar' });
 
       expect(response).toEqual(albumFixture);
-      expect(httpMock.get).toHaveBeenCalledWith('/albums/foo', {
-        params: {
-          market: 'bar',
-        },
-      });
+      expect(getAnAlbumSpy).toHaveBeenCalledWith('foo', 'bar');
     });
   });
 
   describe('getAlbums', () => {
+    let getAlbumsSpy: SpyInstance;
     beforeEach(() => {
-      HttpMock.prototype.get.mockResolvedValue(getAlbumsFixture);
+      getAlbumsSpy = vi
+        .spyOn(AlbumsService, 'getMultipleAlbums')
+        .mockResolvedValue(getAlbumsFixture);
     });
 
-    it.todo('should get several albums (without options)', async () => {
-      const { httpMock, albums } = setup();
-
+    it('should get several albums (without options)', async () => {
       const response = await albums.getAlbums(['foo', 'bar']);
 
       expect(response).toEqual(getAlbumsFixture.albums);
-      expect(httpMock.get).toHaveBeenCalledWith('/albums', {
-        params: {
-          ids: ['foo', 'bar'],
-        },
-      });
+      expect(getAlbumsSpy).toHaveBeenCalledWith('foo,bar', undefined);
     });
 
-    it.todo('should get several albums (with options)', async () => {
-      const { httpMock, albums } = setup();
-
+    it('should get several albums (with options)', async () => {
       const response = await albums.getAlbums(['foo', 'bar'], {
         market: 'baz',
       });
 
       expect(response).toEqual(getAlbumsFixture.albums);
-      expect(httpMock.get).toHaveBeenCalledWith('/albums', {
-        params: {
-          ids: ['foo', 'bar'],
-          market: 'baz',
-        },
-      });
+      expect(getAlbumsSpy).toHaveBeenCalledWith('foo,bar', 'baz');
     });
   });
 
   describe('getAlbumTracks', () => {
+    let getAlbumTracksSpy: SpyInstance;
     beforeEach(() => {
-      HttpMock.prototype.get.mockResolvedValue(getAlbumTracksFixture);
+      getAlbumTracksSpy = vi
+        .spyOn(AlbumsService, 'getAnAlbumsTracks')
+        .mockResolvedValue(getAlbumTracksFixture);
     });
 
-    it.todo("should get an album's tracks (without options)", async () => {
-      const { httpMock, albums } = setup();
-
+    it("should get an album's tracks (without options)", async () => {
       const response = await albums.getAlbumTracks('foo');
 
       expect(response).toEqual(getAlbumTracksFixture);
-      expect(httpMock.get).toHaveBeenCalledWith(
-        '/albums/foo/tracks',
+      expect(getAlbumTracksSpy).toHaveBeenCalledWith(
+        'foo',
+        undefined,
+        undefined,
         undefined,
       );
     });
 
-    it.todo("should get an album's tracks (with options)", async () => {
-      const { httpMock, albums } = setup();
-
-      const response = await albums.getAlbumTracks('foo', { market: 'bar' });
+    it("should get an album's tracks (with options)", async () => {
+      const response = await albums.getAlbumTracks('foo', {
+        market: 'bar',
+        limit: 1,
+        offset: 2,
+      });
 
       expect(response).toEqual(getAlbumTracksFixture);
-      expect(httpMock.get).toHaveBeenCalledWith('/albums/foo/tracks', {
-        params: {
-          market: 'bar',
-        },
-      });
+      expect(getAlbumTracksSpy).toHaveBeenCalledWith('foo', 'bar', 1, 2);
     });
   });
 });

--- a/src/apis/ArtistsApi.test.ts
+++ b/src/apis/ArtistsApi.test.ts
@@ -1,5 +1,6 @@
-import { type MockedClass } from 'vitest';
+import { type SpyInstance } from 'vitest';
 
+import { ArtistsService } from '../openapi/services/ArtistsService';
 import {
   artistFixture,
   getArtistAlbumsFixture,
@@ -7,123 +8,105 @@ import {
   getArtistsFixture,
   getRelatedArtistsFixture,
 } from '../fixtures';
-import { Http } from '../helpers/Http';
 
 import { ArtistsApi } from './ArtistsApi';
 
-vi.mock('../helpers/Http');
-
-const HttpMock = Http as MockedClass<typeof Http>;
-
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-function setup() {
-  const httpMock = new HttpMock('token');
-  const artists = new ArtistsApi();
-
-  return { httpMock, artists };
-}
+const artists = new ArtistsApi();
 
 describe('ArtistsApi', () => {
-  beforeEach(() => {
+  afterEach(() => {
     vi.resetAllMocks();
   });
 
   describe('getArtist', () => {
+    let getArtistSpy: SpyInstance;
     beforeEach(() => {
-      HttpMock.prototype.get.mockResolvedValue(artistFixture);
+      getArtistSpy = vi
+        .spyOn(ArtistsService, 'getAnArtist')
+        .mockResolvedValue(artistFixture);
     });
 
-    it.todo('should get an artist', async () => {
-      const { httpMock, artists } = setup();
-
+    it('should get an artist', async () => {
       const response = await artists.getArtist('foo');
 
       expect(response).toEqual(artistFixture);
-      expect(httpMock.get).toHaveBeenCalledWith('/artists/foo');
+      expect(getArtistSpy).toHaveBeenCalledWith('foo');
     });
   });
 
   describe('getArtistAlbums', () => {
+    let getArtistAlbumsSpy: SpyInstance;
     beforeEach(() => {
-      HttpMock.prototype.get.mockResolvedValue(getArtistAlbumsFixture);
+      getArtistAlbumsSpy = vi
+        .spyOn(ArtistsService, 'getAnArtistsAlbums')
+        .mockResolvedValue(getArtistAlbumsFixture);
     });
 
-    it.todo("should get an artist's albums (without options)", async () => {
-      const { httpMock, artists } = setup();
-
+    it("should get an artist's albums (without options)", async () => {
       const response = await artists.getArtistAlbums('foo');
 
       expect(response).toEqual(getArtistAlbumsFixture);
-      expect(httpMock.get).toHaveBeenCalledWith(
-        '/artists/foo/albums',
+      expect(getArtistAlbumsSpy).toHaveBeenCalledWith(
+        'foo',
+        undefined,
+        undefined,
+        undefined,
         undefined,
       );
     });
 
-    it.todo("should get an artist's albums (with options)", async () => {
-      const { httpMock, artists } = setup();
-
-      const response = await artists.getArtistAlbums('foo', { market: 'bar' });
+    it("should get an artist's albums (with options)", async () => {
+      const response = await artists.getArtistAlbums('foo', {
+        market: 'bar',
+        include_groups: ['album', 'appears_on', 'compilation', 'single'],
+        limit: 1,
+        offset: 2,
+      });
 
       expect(response).toEqual(getArtistAlbumsFixture);
-      expect(httpMock.get).toHaveBeenCalledWith('/artists/foo/albums', {
-        params: {
-          country: 'bar',
-        },
-      });
+      expect(getArtistAlbumsSpy).toHaveBeenCalledWith(
+        'foo',
+        'album,appears_on,compilation,single',
+        'bar',
+        1,
+        2,
+      );
     });
   });
 
   describe('getArtists', () => {
-    beforeEach(() => {
-      HttpMock.prototype.get.mockResolvedValue(getArtistsFixture);
-    });
-
-    it.todo('should get several artists', async () => {
-      const { httpMock, artists } = setup();
-
+    it('should get several artists', async () => {
+      const getArtistsSpy = vi
+        .spyOn(ArtistsService, 'getMultipleArtists')
+        .mockResolvedValue(getArtistsFixture);
       const response = await artists.getArtists(['foo', 'bar']);
 
       expect(response).toEqual(getArtistsFixture.artists);
-      expect(httpMock.get).toHaveBeenCalledWith('/artists', {
-        params: {
-          ids: ['foo', 'bar'],
-        },
-      });
+      expect(getArtistsSpy).toHaveBeenCalledWith('foo,bar');
     });
   });
 
   describe('getArtistTopTracks', () => {
-    beforeEach(() => {
-      HttpMock.prototype.get.mockResolvedValue(getArtistTopTracksFixture);
-    });
-
-    it.todo("should get an artist's top tracks", async () => {
-      const { httpMock, artists } = setup();
-
+    it("should get an artist's top tracks", async () => {
+      const getArtistTopTracksSpy = vi
+        .spyOn(ArtistsService, 'getAnArtistsTopTracks')
+        .mockResolvedValue(getArtistTopTracksFixture);
       const response = await artists.getArtistTopTracks('foo', 'bar');
 
       expect(response).toEqual(getArtistTopTracksFixture.tracks);
-      expect(httpMock.get).toHaveBeenCalledWith('/artists/foo/top-tracks', {
-        params: {
-          country: 'bar',
-        },
-      });
+      expect(getArtistTopTracksSpy).toHaveBeenCalledWith('foo', 'bar');
     });
   });
 
   describe('getRelatedArtists', () => {
-    beforeEach(() => {
-      HttpMock.prototype.get.mockResolvedValue(getRelatedArtistsFixture);
-    });
-
-    it.todo("should get an artist's related artists", async () => {
-      const { httpMock, artists } = setup();
-
+    it("should get an artist's related artists", async () => {
+      const getRelatedArtistsSpy = vi
+        .spyOn(ArtistsService, 'getAnArtistsRelatedArtists')
+        .mockResolvedValue(getRelatedArtistsFixture);
       const response = await artists.getRelatedArtists('foo');
 
       expect(response).toEqual(getRelatedArtistsFixture.artists);
-      expect(httpMock.get).toHaveBeenCalledWith('/artists/foo/related-artists');
+      expect(getRelatedArtistsSpy).toHaveBeenCalledWith('foo');
     });
   });
 });

--- a/src/apis/AudiobooksApi.test.ts
+++ b/src/apis/AudiobooksApi.test.ts
@@ -1,0 +1,98 @@
+import { type SpyInstance } from 'vitest';
+
+import {
+  audiobookFixture,
+  getAudiobookChaptersFixture,
+  getAudiobooksFixture,
+} from '../fixtures';
+import { AudiobooksService } from '../openapi/services/AudiobooksService';
+
+import { AudiobooksApi } from './AudiobooksApi';
+
+const audiobooks = new AudiobooksApi();
+
+describe('AudiobooksApi', () => {
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('getAudiobook', () => {
+    let getAnAudiobookSpy: SpyInstance;
+    beforeEach(() => {
+      getAnAudiobookSpy = vi
+        .spyOn(AudiobooksService, 'getAnAudiobook')
+        .mockResolvedValue(audiobookFixture);
+    });
+
+    it('should get an audiobook (without options)', async () => {
+      const response = await audiobooks.getAudiobook('foo');
+
+      expect(response).toEqual(audiobookFixture);
+      expect(getAnAudiobookSpy).toHaveBeenCalledWith('foo', undefined);
+    });
+
+    it('should get an audiobook (with options)', async () => {
+      const response = await audiobooks.getAudiobook('foo', { market: 'bar' });
+
+      expect(response).toEqual(audiobookFixture);
+      expect(getAnAudiobookSpy).toHaveBeenCalledWith('foo', 'bar');
+    });
+  });
+
+  describe('getAudiobooks', () => {
+    let getAudiobooksSpy: SpyInstance;
+    beforeEach(() => {
+      getAudiobooksSpy = vi
+        .spyOn(AudiobooksService, 'getMultipleAudiobooks')
+        .mockResolvedValue(getAudiobooksFixture);
+    });
+
+    it('should get several audiobooks (without options)', async () => {
+      const response = await audiobooks.getAudiobooks(['foo', 'bar']);
+
+      expect(response).toEqual(getAudiobooksFixture.audiobooks);
+      expect(getAudiobooksSpy).toHaveBeenCalledWith('foo,bar', undefined);
+    });
+
+    it('should get several audiobooks (with options)', async () => {
+      const response = await audiobooks.getAudiobooks(['foo', 'bar'], {
+        market: 'baz',
+      });
+
+      expect(response).toEqual(getAudiobooksFixture.audiobooks);
+      expect(getAudiobooksSpy).toHaveBeenCalledWith('foo,bar', 'baz');
+    });
+  });
+
+  describe('getAudiobookChapters', () => {
+    let getAudiobookChaptersSpy: SpyInstance;
+    beforeEach(() => {
+      getAudiobookChaptersSpy = vi
+        .spyOn(AudiobooksService, 'getAudiobookChapters')
+        .mockResolvedValue(getAudiobookChaptersFixture);
+    });
+
+    it("should get an audiobook's chapters (without options)", async () => {
+      const response = await audiobooks.getAudiobookChapters('foo');
+
+      expect(response).toEqual(getAudiobookChaptersFixture);
+      expect(getAudiobookChaptersSpy).toHaveBeenCalledWith(
+        'foo',
+        undefined,
+        undefined,
+        undefined,
+      );
+    });
+
+    it("should get an audiobook's chapters (with options)", async () => {
+      const response = await audiobooks.getAudiobookChapters('foo', {
+        market: 'bar',
+        limit: 1,
+        offset: 2,
+      });
+
+      expect(response).toEqual(getAudiobookChaptersFixture);
+      expect(getAudiobookChaptersSpy).toHaveBeenCalledWith('foo', 'bar', 1, 2);
+    });
+  });
+});

--- a/src/apis/EpisodesApi.test.ts
+++ b/src/apis/EpisodesApi.test.ts
@@ -1,87 +1,62 @@
-import { type MockedClass } from 'vitest';
+import { type SpyInstance } from 'vitest';
 
 import { episodeFixture, getEpisodesFixture } from '../fixtures';
-import { Http } from '../helpers/Http';
+import { EpisodesService } from '../openapi/services/EpisodesService';
 
 import { EpisodesApi } from './EpisodesApi';
 
-vi.mock('../helpers/Http');
-
-const HttpMock = Http as MockedClass<typeof Http>;
-
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-function setup() {
-  const httpMock = new HttpMock('token');
-  const episodes = new EpisodesApi();
-
-  return { httpMock, episodes };
-}
+const episodes = new EpisodesApi();
 
 describe('EpisodesApi', () => {
-  beforeEach(() => {
+  afterEach(() => {
     vi.resetAllMocks();
   });
 
   describe('getEpisode', () => {
+    let getEpisodeSpy: SpyInstance;
     beforeEach(() => {
-      HttpMock.prototype.get.mockResolvedValue(episodeFixture);
+      getEpisodeSpy = vi
+        .spyOn(EpisodesService, 'getAnEpisode')
+        .mockResolvedValue(episodeFixture);
     });
 
-    it.todo('should get an episode (without options)', async () => {
-      const { httpMock, episodes } = setup();
-
+    it('should get an episode (without options)', async () => {
       const response = await episodes.getEpisode('foo');
 
       expect(response).toEqual(episodeFixture);
-      expect(httpMock.get).toHaveBeenCalledWith('/episodes/foo', undefined);
+      expect(getEpisodeSpy).toHaveBeenCalledWith('foo', undefined);
     });
 
-    it.todo('should get an episode (with options)', async () => {
-      const { httpMock, episodes } = setup();
-
+    it('should get an episode (with options)', async () => {
       const response = await episodes.getEpisode('foo', { market: 'bar' });
 
       expect(response).toEqual(episodeFixture);
-      expect(httpMock.get).toHaveBeenCalledWith('/episodes/foo', {
-        params: {
-          market: 'bar',
-        },
-      });
+      expect(getEpisodeSpy).toHaveBeenCalledWith('foo', 'bar');
     });
   });
 
   describe('getEpisodes', () => {
+    let getEpisodesSpy: SpyInstance;
     beforeEach(() => {
-      HttpMock.prototype.get.mockResolvedValue(getEpisodesFixture);
+      getEpisodesSpy = vi
+        .spyOn(EpisodesService, 'getMultipleEpisodes')
+        .mockResolvedValue(getEpisodesFixture);
     });
 
-    it.todo('should get several episodes (without options)', async () => {
-      const { httpMock, episodes } = setup();
-
+    it('should get several episodes (without options)', async () => {
       const response = await episodes.getEpisodes(['foo', 'bar']);
 
       expect(response).toEqual(getEpisodesFixture.episodes);
-      expect(httpMock.get).toHaveBeenCalledWith('/episodes', {
-        params: {
-          ids: ['foo', 'bar'],
-        },
-      });
+      expect(getEpisodesSpy).toHaveBeenCalledWith('foo,bar', undefined);
     });
 
-    it.todo('should get several episodes (with options)', async () => {
-      const { httpMock, episodes } = setup();
-
+    it('should get several episodes (with options)', async () => {
       const response = await episodes.getEpisodes(['foo', 'bar'], {
         market: 'baz',
       });
 
       expect(response).toEqual(getEpisodesFixture.episodes);
-      expect(httpMock.get).toHaveBeenCalledWith('/episodes', {
-        params: {
-          ids: ['foo', 'bar'],
-          market: 'baz',
-        },
-      });
+      expect(getEpisodesSpy).toHaveBeenCalledWith('foo,bar', 'baz');
     });
   });
 });

--- a/src/apis/FollowApi.test.ts
+++ b/src/apis/FollowApi.test.ts
@@ -141,9 +141,9 @@ describe('FollowApi', () => {
   });
 
   describe('isFollowingPlaylist', () => {
-    it.todo('should check if a user follows a playlist', async () => {
+    it('should check if a user follows a playlist', async () => {
       const isFollowingPlaylistSpy = vi
-        .spyOn(UsersService, 'checkCurrentUserFollows')
+        .spyOn(UsersService, 'checkIfUserFollowsPlaylist')
         .mockResolvedValue([true]);
       const response = await follow.isFollowingPlaylist('foo', 'bar');
 

--- a/src/apis/LibraryApi.test.ts
+++ b/src/apis/LibraryApi.test.ts
@@ -1,450 +1,498 @@
-import { type MockedClass } from 'vitest';
+import { type SpyInstance } from 'vitest';
 
 import {
   getSavedAlbumsFixture,
+  getSavedAudiobooksFixture,
+  getSavedEpisodesFixture,
   getSavedShowsFixture,
   getSavedTracksFixture,
 } from '../fixtures';
-import { Http } from '../helpers/Http';
+import { LibraryService } from '../openapi/services/LibraryService';
 
 import { LibraryApi } from './LibraryApi';
 
-vi.mock('../helpers/Http');
-
-const HttpMock = Http as MockedClass<typeof Http>;
-
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-function setup() {
-  const httpMock = new HttpMock('token');
-  const library = new LibraryApi();
-
-  return { httpMock, library };
-}
+const library = new LibraryApi();
 
 describe('LibraryApi', () => {
-  beforeEach(() => {
+  afterEach(() => {
     vi.resetAllMocks();
   });
 
   describe('areAlbumsSaved', () => {
+    let areAlbumsSavedSpy: SpyInstance;
     beforeEach(() => {
-      HttpMock.prototype.get.mockResolvedValue([true, false]);
+      areAlbumsSavedSpy = vi
+        .spyOn(LibraryService, 'checkUsersSavedAlbums')
+        .mockResolvedValue([true, false]);
     });
 
-    it.todo("should check the user's saved albums", async () => {
-      const { httpMock, library } = setup();
+    it("should check if an album is in user's library", async () => {
+      const response = await library.isAlbumSaved('foo');
 
+      expect(response).toBeTruthy();
+      expect(areAlbumsSavedSpy).toHaveBeenCalledWith('foo');
+    });
+
+    it("should check the user's saved albums", async () => {
       const response = await library.areAlbumsSaved(['foo', 'bar']);
 
       expect(response).toEqual([true, false]);
-      expect(httpMock.get).toHaveBeenCalledWith('/me/albums/contains', {
-        params: {
-          ids: ['foo', 'bar'],
-        },
-      });
+      expect(areAlbumsSavedSpy).toHaveBeenCalledWith('foo,bar');
+    });
+  });
+  describe('areAudiobooksSaved', () => {
+    let areAudiobooksSavedSpy: SpyInstance;
+    beforeEach(() => {
+      areAudiobooksSavedSpy = vi
+        .spyOn(LibraryService, 'checkUsersSavedAudiobooks')
+        .mockResolvedValue([true, false]);
+    });
+
+    it("should check if an album is in user's library", async () => {
+      const response = await library.isAudiobookSaved('foo');
+
+      expect(response).toBeTruthy();
+      expect(areAudiobooksSavedSpy).toHaveBeenCalledWith('foo');
+    });
+
+    it("should check the user's saved audiobooks", async () => {
+      const response = await library.areAudiobooksSaved(['foo', 'bar']);
+
+      expect(response).toEqual([true, false]);
+      expect(areAudiobooksSavedSpy).toHaveBeenCalledWith('foo,bar');
+    });
+  });
+
+  describe('areEpisodesSaved', () => {
+    let areEpisodesSavedSpy: SpyInstance;
+    beforeEach(() => {
+      areEpisodesSavedSpy = vi
+        .spyOn(LibraryService, 'checkUsersSavedEpisodes')
+        .mockResolvedValue([true, false]);
+    });
+
+    it("should check if an episode is in user's library", async () => {
+      const response = await library.isEpisodeSaved('foo');
+
+      expect(response).toBeTruthy();
+      expect(areEpisodesSavedSpy).toHaveBeenCalledWith('foo');
+    });
+
+    it("should check the user's saved episodes", async () => {
+      const response = await library.areEpisodesSaved(['foo', 'bar']);
+
+      expect(response).toEqual([true, false]);
+      expect(areEpisodesSavedSpy).toHaveBeenCalledWith('foo,bar');
     });
   });
 
   describe('areShowsSaved', () => {
+    let areShowsSavedSpy: SpyInstance;
     beforeEach(() => {
-      HttpMock.prototype.get.mockResolvedValue([true, false]);
+      areShowsSavedSpy = vi
+        .spyOn(LibraryService, 'checkUsersSavedShows')
+        .mockResolvedValue([true, false]);
     });
 
-    it.todo("should check the user's saved shows", async () => {
-      const { httpMock, library } = setup();
+    it("should check if a show is in user's library", async () => {
+      const response = await library.isShowSaved('foo');
 
+      expect(response).toBeTruthy();
+      expect(areShowsSavedSpy).toHaveBeenCalledWith('foo');
+    });
+
+    it("should check the user's saved shows", async () => {
       const response = await library.areShowsSaved(['foo', 'bar']);
 
       expect(response).toEqual([true, false]);
-      expect(httpMock.get).toHaveBeenCalledWith('/me/shows/contains', {
-        params: {
-          ids: ['foo', 'bar'],
-        },
-      });
+      expect(areShowsSavedSpy).toHaveBeenCalledWith('foo,bar');
     });
   });
 
   describe('areTracksSaved', () => {
+    let areTracksSavedSpy: SpyInstance;
     beforeEach(() => {
-      HttpMock.prototype.get.mockResolvedValue([true, false]);
+      areTracksSavedSpy = vi
+        .spyOn(LibraryService, 'checkUsersSavedTracks')
+        .mockResolvedValue([true, false]);
     });
 
-    it.todo("should check the user's saved tracks", async () => {
-      const { httpMock, library } = setup();
+    it("should check if a track is in user's library", async () => {
+      const response = await library.isTrackSaved('foo');
 
+      expect(response).toBeTruthy();
+      expect(areTracksSavedSpy).toHaveBeenCalledWith('foo');
+    });
+
+    it("should check the user's saved tracks", async () => {
       const response = await library.areTracksSaved(['foo', 'bar']);
 
       expect(response).toEqual([true, false]);
-      expect(httpMock.get).toHaveBeenCalledWith('/me/tracks/contains', {
-        params: {
-          ids: ['foo', 'bar'],
-        },
-      });
+      expect(areTracksSavedSpy).toHaveBeenCalledWith('foo,bar');
     });
   });
 
   describe('getSavedAlbums', () => {
+    let getSavedAlbumsSpy: SpyInstance;
     beforeEach(() => {
-      HttpMock.prototype.get.mockResolvedValue(getSavedAlbumsFixture);
+      getSavedAlbumsSpy = vi
+        .spyOn(LibraryService, 'getUsersSavedAlbums')
+        .mockResolvedValue(getSavedAlbumsFixture);
     });
 
-    it.todo(
-      "should get the current user's saved albums (without options)",
-      async () => {
-        const { httpMock, library } = setup();
+    it("should get the current user's saved albums (without options)", async () => {
+      const response = await library.getSavedAlbums();
 
-        const response = await library.getSavedAlbums();
+      expect(response).toEqual(getSavedAlbumsFixture);
+      expect(getSavedAlbumsSpy).toHaveBeenCalledWith(
+        undefined,
+        undefined,
+        undefined,
+      );
+    });
 
-        expect(response).toEqual(getSavedAlbumsFixture);
-        expect(httpMock.get).toHaveBeenCalledWith('/me/albums', undefined);
-      },
-    );
+    it("should get the current user's saved albums (with options)", async () => {
+      const response = await library.getSavedAlbums({
+        limit: 1,
+        offset: 2,
+        market: 'foo',
+      });
 
-    it.todo(
-      "should get the current user's saved albums (with options)",
-      async () => {
-        const { httpMock, library } = setup();
+      expect(response).toEqual(getSavedAlbumsFixture);
+      expect(getSavedAlbumsSpy).toHaveBeenCalledWith(1, 2, 'foo');
+    });
+  });
 
-        const response = await library.getSavedAlbums({ limit: 2 });
+  describe('getSavedAudiobooks', () => {
+    let getSavedAudiobooksSpy: SpyInstance;
+    beforeEach(() => {
+      getSavedAudiobooksSpy = vi
+        .spyOn(LibraryService, 'getUsersSavedAudiobooks')
+        .mockResolvedValue(getSavedAudiobooksFixture);
+    });
 
-        expect(response).toEqual(getSavedAlbumsFixture);
-        expect(httpMock.get).toHaveBeenCalledWith('/me/albums', {
-          params: {
-            limit: 2,
-          },
-        });
-      },
-    );
+    it("should get the current user's saved audiobooks (without options)", async () => {
+      const response = await library.getSavedAudiobooks();
+
+      expect(response).toEqual(getSavedAudiobooksFixture);
+      expect(getSavedAudiobooksSpy).toHaveBeenCalledWith(undefined, undefined);
+    });
+
+    it("should get the current user's saved audiobooks (with options)", async () => {
+      const response = await library.getSavedAudiobooks({
+        limit: 1,
+        offset: 2,
+      });
+
+      expect(response).toEqual(getSavedAudiobooksFixture);
+      expect(getSavedAudiobooksSpy).toHaveBeenCalledWith(1, 2);
+    });
+  });
+
+  describe('getSavedEpisodes', () => {
+    let getSavedEpisodesSpy: SpyInstance;
+    beforeEach(() => {
+      getSavedEpisodesSpy = vi
+        .spyOn(LibraryService, 'getUsersSavedEpisodes')
+        .mockResolvedValue(getSavedEpisodesFixture);
+    });
+
+    it("should get the current user's saved episodes (without options)", async () => {
+      const response = await library.getSavedEpisodes();
+
+      expect(response).toEqual(getSavedEpisodesFixture);
+      expect(getSavedEpisodesSpy).toHaveBeenCalledWith(
+        undefined,
+        undefined,
+        undefined,
+      );
+    });
+
+    it("should get the current user's saved episodes (with options)", async () => {
+      const response = await library.getSavedEpisodes({
+        limit: 1,
+        offset: 2,
+        market: 'foo',
+      });
+
+      expect(response).toEqual(getSavedEpisodesFixture);
+      expect(getSavedEpisodesSpy).toHaveBeenCalledWith('foo', 1, 2);
+    });
   });
 
   describe('getSavedShows', () => {
+    let getSavedShowsSpy: SpyInstance;
     beforeEach(() => {
-      HttpMock.prototype.get.mockResolvedValue(getSavedShowsFixture);
+      getSavedShowsSpy = vi
+        .spyOn(LibraryService, 'getUsersSavedShows')
+        .mockResolvedValue(getSavedShowsFixture);
     });
 
-    it.todo(
-      "should get the current user's saved shows (without options)",
-      async () => {
-        const { httpMock, library } = setup();
+    it("should get the current user's saved shows (without options)", async () => {
+      const response = await library.getSavedShows();
 
-        const response = await library.getSavedShows();
+      expect(response).toEqual(getSavedShowsFixture);
+      expect(getSavedShowsSpy).toHaveBeenCalledWith(undefined, undefined);
+    });
 
-        expect(response).toEqual(getSavedShowsFixture);
-        expect(httpMock.get).toHaveBeenCalledWith('/me/shows', undefined);
-      },
-    );
+    it("should get the current user's saved shows (with options)", async () => {
+      const response = await library.getSavedShows({ limit: 1, offset: 2 });
 
-    it.todo(
-      "should get the current user's saved shows (with options)",
-      async () => {
-        const { httpMock, library } = setup();
-
-        const response = await library.getSavedShows({ limit: 2 });
-
-        expect(response).toEqual(getSavedShowsFixture);
-        expect(httpMock.get).toHaveBeenCalledWith('/me/shows', {
-          params: {
-            limit: 2,
-          },
-        });
-      },
-    );
+      expect(response).toEqual(getSavedShowsFixture);
+      expect(getSavedShowsSpy).toHaveBeenCalledWith(1, 2);
+    });
   });
 
   describe('getSavedTracks', () => {
+    let getSavedTracksSpy: SpyInstance;
     beforeEach(() => {
-      HttpMock.prototype.get.mockResolvedValue(getSavedTracksFixture);
+      getSavedTracksSpy = vi
+        .spyOn(LibraryService, 'getUsersSavedTracks')
+        .mockResolvedValue(getSavedTracksFixture);
     });
 
-    it.todo(
-      "should get the current user's saved tracks (without options)",
-      async () => {
-        const { httpMock, library } = setup();
+    it("should get the current user's saved tracks (without options)", async () => {
+      const response = await library.getSavedTracks();
 
-        const response = await library.getSavedTracks();
-
-        expect(response).toEqual(getSavedTracksFixture);
-        expect(httpMock.get).toHaveBeenCalledWith('/me/tracks', undefined);
-      },
-    );
-
-    it.todo(
-      "should get the current user's saved tracks (with options)",
-      async () => {
-        const { httpMock, library } = setup();
-
-        const response = await library.getSavedTracks({ limit: 2 });
-
-        expect(response).toEqual(getSavedTracksFixture);
-        expect(httpMock.get).toHaveBeenCalledWith('/me/tracks', {
-          params: {
-            limit: 2,
-          },
-        });
-      },
-    );
-  });
-
-  describe('isAlbumSaved', () => {
-    beforeEach(() => {
-      HttpMock.prototype.get.mockResolvedValue([true]);
+      expect(response).toEqual(getSavedTracksFixture);
+      expect(getSavedTracksSpy).toHaveBeenCalledWith(
+        undefined,
+        undefined,
+        undefined,
+      );
     });
 
-    it.todo("should check the user's saved albums", async () => {
-      const { httpMock, library } = setup();
-
-      const response = await library.isAlbumSaved('foo');
-
-      expect(response).toBeTruthy();
-      expect(httpMock.get).toHaveBeenCalledWith('/me/albums/contains', {
-        params: {
-          ids: ['foo'],
-        },
+    it("should get the current user's saved tracks (with options)", async () => {
+      const response = await library.getSavedTracks({
+        limit: 1,
+        offset: 2,
+        market: 'foo',
       });
-    });
-  });
 
-  describe('isShowSaved', () => {
-    beforeEach(() => {
-      HttpMock.prototype.get.mockResolvedValue([true]);
-    });
-
-    it.todo("should check the user's saved shows", async () => {
-      const { httpMock, library } = setup();
-
-      const response = await library.isShowSaved('foo');
-
-      expect(response).toBeTruthy();
-      expect(httpMock.get).toHaveBeenCalledWith('/me/shows/contains', {
-        params: {
-          ids: ['foo'],
-        },
-      });
-    });
-  });
-
-  describe('isTrackSaved', () => {
-    beforeEach(() => {
-      HttpMock.prototype.get.mockResolvedValue([true]);
-    });
-
-    it.todo("should check the user's saved tracks", async () => {
-      const { httpMock, library } = setup();
-
-      const response = await library.isTrackSaved('foo');
-
-      expect(response).toBeTruthy();
-      expect(httpMock.get).toHaveBeenCalledWith('/me/tracks/contains', {
-        params: {
-          ids: ['foo'],
-        },
-      });
-    });
-  });
-
-  describe('removeSavedAlbum', () => {
-    it.todo('should remove an album for the current user', async () => {
-      const { httpMock, library } = setup();
-
-      await library.removeSavedAlbum('foo');
-
-      expect(httpMock.delete).toHaveBeenCalledWith('/me/albums', {
-        data: {
-          ids: ['foo'],
-        },
-      });
+      expect(response).toEqual(getSavedTracksFixture);
+      expect(getSavedTracksSpy).toHaveBeenCalledWith('foo', 1, 2);
     });
   });
 
   describe('removeSavedAlbums', () => {
-    it.todo('should remove albums for the current user', async () => {
-      const { httpMock, library } = setup();
+    let removeSavedAlbumsSpy: SpyInstance;
+    beforeEach(() => {
+      removeSavedAlbumsSpy = vi
+        .spyOn(LibraryService, 'removeAlbumsUser')
+        .mockResolvedValue(undefined);
+    });
 
+    it('should remove an album for the current user', async () => {
+      await library.removeSavedAlbum('foo');
+
+      expect(removeSavedAlbumsSpy).toHaveBeenCalledWith('foo');
+    });
+
+    it('should remove albums for the current user', async () => {
       await library.removeSavedAlbums(['foo', 'bar']);
 
-      expect(httpMock.delete).toHaveBeenCalledWith('/me/albums', {
-        data: {
-          ids: ['foo', 'bar'],
-        },
-      });
+      expect(removeSavedAlbumsSpy).toHaveBeenCalledWith('foo,bar');
     });
   });
 
-  describe('removeSavedShow', () => {
-    it.todo(
-      'should remove a show for the current user (without options)',
-      async () => {
-        const { httpMock, library } = setup();
+  describe('removeSavedAudiobooks', () => {
+    let removeSavedAudiobooksSpy: SpyInstance;
+    beforeEach(() => {
+      removeSavedAudiobooksSpy = vi
+        .spyOn(LibraryService, 'removeAudiobooksUser')
+        .mockResolvedValue(undefined);
+    });
 
-        await library.removeSavedShow('foo');
+    it('should remove an audiobook for the current user', async () => {
+      await library.removeSavedAudiobook('foo');
 
-        expect(httpMock.delete).toHaveBeenCalledWith('/me/shows', {
-          params: {
-            ids: ['foo'],
-          },
-        });
-      },
-    );
+      expect(removeSavedAudiobooksSpy).toHaveBeenCalledWith('foo');
+    });
 
-    it.todo(
-      'should remove a show for the current user (with options)',
-      async () => {
-        const { httpMock, library } = setup();
+    it('should remove audiobooks for the current user', async () => {
+      await library.removeSavedAudiobooks(['foo', 'bar']);
 
-        await library.removeSavedShow('foo', { market: 'bar' });
+      expect(removeSavedAudiobooksSpy).toHaveBeenCalledWith('foo,bar');
+    });
+  });
 
-        expect(httpMock.delete).toHaveBeenCalledWith('/me/shows', {
-          params: {
-            ids: ['foo'],
-            market: 'bar',
-          },
-        });
-      },
-    );
+  describe('removeSavedEpisodes', () => {
+    let removeSavedEpisodesSpy: SpyInstance;
+    beforeEach(() => {
+      removeSavedEpisodesSpy = vi
+        .spyOn(LibraryService, 'removeEpisodesUser')
+        .mockResolvedValue(undefined);
+    });
+
+    it('should remove an episode for the current user', async () => {
+      await library.removeSavedEpisode('foo');
+
+      expect(removeSavedEpisodesSpy).toHaveBeenCalledWith('foo');
+    });
+
+    it('should remove episodes for the current user', async () => {
+      await library.removeSavedEpisodes(['foo', 'bar']);
+
+      expect(removeSavedEpisodesSpy).toHaveBeenCalledWith('foo,bar');
+    });
   });
 
   describe('removeSavedShows', () => {
-    it.todo(
-      'should remove shows for the current user (without options)',
-      async () => {
-        const { httpMock, library } = setup();
+    let removeSavedShowsSpy: SpyInstance;
+    beforeEach(() => {
+      removeSavedShowsSpy = vi
+        .spyOn(LibraryService, 'removeShowsUser')
+        .mockResolvedValue(undefined);
+    });
 
-        await library.removeSavedShows(['foo', 'bar']);
+    it('should remove a show for the current user (without options)', async () => {
+      await library.removeSavedShow('foo');
 
-        expect(httpMock.delete).toHaveBeenCalledWith('/me/shows', {
-          params: {
-            ids: ['foo', 'bar'],
-          },
-        });
-      },
-    );
+      expect(removeSavedShowsSpy).toHaveBeenCalledWith('foo', undefined);
+    });
 
-    it.todo(
-      'should remove shows for the current user (with options)',
-      async () => {
-        const { httpMock, library } = setup();
+    it('should remove a show for the current user (with options)', async () => {
+      await library.removeSavedShow('foo', { market: 'bar' });
 
-        await library.removeSavedShows(['foo', 'bar'], { market: 'baz' });
+      expect(removeSavedShowsSpy).toHaveBeenCalledWith('foo', 'bar');
+    });
 
-        expect(httpMock.delete).toHaveBeenCalledWith('/me/shows', {
-          params: {
-            ids: ['foo', 'bar'],
-            market: 'baz',
-          },
-        });
-      },
-    );
-  });
+    it('should remove shows for the current user (without options)', async () => {
+      await library.removeSavedShows(['foo', 'bar']);
 
-  describe('removeSavedTrack', () => {
-    it.todo('should remove a track for the current user', async () => {
-      const { httpMock, library } = setup();
+      expect(removeSavedShowsSpy).toHaveBeenCalledWith('foo,bar', undefined);
+    });
 
-      await library.removeSavedTrack('foo');
+    it('should remove shows for the current user (with options)', async () => {
+      await library.removeSavedShows(['foo', 'bar'], { market: 'baz' });
 
-      expect(httpMock.delete).toHaveBeenCalledWith('/me/tracks', {
-        data: {
-          ids: ['foo'],
-        },
-      });
+      expect(removeSavedShowsSpy).toHaveBeenCalledWith('foo,bar', 'baz');
     });
   });
 
   describe('removeSavedTracks', () => {
-    it.todo('should remove tracks for the current user', async () => {
-      const { httpMock, library } = setup();
+    let removeSavedTracksSpy: SpyInstance;
+    beforeEach(() => {
+      removeSavedTracksSpy = vi
+        .spyOn(LibraryService, 'removeTracksUser')
+        .mockResolvedValue(undefined);
+    });
 
+    it('should remove a track for the current user', async () => {
+      await library.removeSavedTrack('foo');
+
+      expect(removeSavedTracksSpy).toHaveBeenCalledWith('foo');
+    });
+
+    it('should remove tracks for the current user', async () => {
       await library.removeSavedTracks(['foo', 'bar']);
 
-      expect(httpMock.delete).toHaveBeenCalledWith('/me/tracks', {
-        data: {
-          ids: ['foo', 'bar'],
-        },
-      });
-    });
-  });
-
-  describe('saveAlbum', () => {
-    it.todo('should save an album for the current user', async () => {
-      const { httpMock, library } = setup();
-
-      await library.saveAlbum('foo');
-
-      expect(httpMock.put).toHaveBeenCalledWith('/me/albums', {
-        data: {
-          ids: ['foo'],
-        },
-      });
+      expect(removeSavedTracksSpy).toHaveBeenCalledWith('foo,bar');
     });
   });
 
   describe('saveAlbums', () => {
-    it.todo('should save albums for the current user', async () => {
-      const { httpMock, library } = setup();
+    let saveAlbumsSpy: SpyInstance;
+    beforeEach(() => {
+      saveAlbumsSpy = vi
+        .spyOn(LibraryService, 'saveAlbumsUser')
+        .mockResolvedValue(undefined);
+    });
 
+    it('should save an album for the current user', async () => {
+      await library.saveAlbum('foo');
+
+      expect(saveAlbumsSpy).toHaveBeenCalledWith('foo');
+    });
+
+    it('should save albums for the current user', async () => {
       await library.saveAlbums(['foo', 'bar']);
 
-      expect(httpMock.put).toHaveBeenCalledWith('/me/albums', {
-        data: {
-          ids: ['foo', 'bar'],
-        },
-      });
+      expect(saveAlbumsSpy).toHaveBeenCalledWith('foo,bar');
     });
   });
 
-  describe('saveShow', () => {
-    it.todo('should save a show for the current user', async () => {
-      const { httpMock, library } = setup();
+  describe('saveAudiobooks', () => {
+    let saveAudiobooksSpy: SpyInstance;
+    beforeEach(() => {
+      saveAudiobooksSpy = vi
+        .spyOn(LibraryService, 'saveAudiobooksUser')
+        .mockResolvedValue(undefined);
+    });
 
-      await library.saveShow('foo');
+    it('should save an audiobook for the current user', async () => {
+      await library.saveAudiobook('foo');
 
-      expect(httpMock.put).toHaveBeenCalledWith('/me/shows', {
-        params: {
-          ids: ['foo'],
-        },
-      });
+      expect(saveAudiobooksSpy).toHaveBeenCalledWith('foo');
+    });
+
+    it('should save audiobooks for the current user', async () => {
+      await library.saveAudiobooks(['foo', 'bar']);
+
+      expect(saveAudiobooksSpy).toHaveBeenCalledWith('foo,bar');
+    });
+  });
+
+  describe('saveEpisodes', () => {
+    let saveEpisodesSpy: SpyInstance;
+    beforeEach(() => {
+      saveEpisodesSpy = vi
+        .spyOn(LibraryService, 'saveEpisodesUser')
+        .mockResolvedValue(undefined);
+    });
+
+    it('should save an episode for the current user', async () => {
+      await library.saveEpisode('foo');
+
+      expect(saveEpisodesSpy).toHaveBeenCalledWith('foo');
+    });
+
+    it('should save episodes for the current user', async () => {
+      await library.saveEpisodes(['foo', 'bar']);
+
+      expect(saveEpisodesSpy).toHaveBeenCalledWith('foo,bar');
     });
   });
 
   describe('saveShows', () => {
-    it.todo('should save shows for the current user', async () => {
-      const { httpMock, library } = setup();
+    let saveShowsSpy: SpyInstance;
+    beforeEach(() => {
+      saveShowsSpy = vi
+        .spyOn(LibraryService, 'saveShowsUser')
+        .mockResolvedValue(undefined);
+    });
 
+    it('should save a show for the current user', async () => {
+      await library.saveShow('foo');
+
+      expect(saveShowsSpy).toHaveBeenCalledWith('foo');
+    });
+
+    it('should save shows for the current user', async () => {
       await library.saveShows(['foo', 'bar']);
 
-      expect(httpMock.put).toHaveBeenCalledWith('/me/shows', {
-        params: {
-          ids: ['foo', 'bar'],
-        },
-      });
-    });
-  });
-
-  describe('saveTrack', () => {
-    it.todo('should save a track for the current user', async () => {
-      const { httpMock, library } = setup();
-
-      await library.saveTrack('foo');
-
-      expect(httpMock.put).toHaveBeenCalledWith('/me/tracks', {
-        data: {
-          ids: ['foo'],
-        },
-      });
+      expect(saveShowsSpy).toHaveBeenCalledWith('foo,bar');
     });
   });
 
   describe('saveTracks', () => {
-    it.todo('should save tracks for the current user', async () => {
-      const { httpMock, library } = setup();
+    let saveTracksSpy: SpyInstance;
+    beforeEach(() => {
+      saveTracksSpy = vi
+        .spyOn(LibraryService, 'saveTracksUser')
+        .mockResolvedValue(undefined);
+    });
 
+    it('should save a track for the current user', async () => {
+      await library.saveTrack('foo');
+
+      expect(saveTracksSpy).toHaveBeenCalledWith('foo');
+    });
+
+    it('should save tracks for the current user', async () => {
       await library.saveTracks(['foo', 'bar']);
 
-      expect(httpMock.put).toHaveBeenCalledWith('/me/tracks', {
-        data: {
-          ids: ['foo', 'bar'],
-        },
-      });
+      expect(saveTracksSpy).toHaveBeenCalledWith('foo,bar');
     });
   });
 });

--- a/src/apis/MarketsApi.test.ts
+++ b/src/apis/MarketsApi.test.ts
@@ -1,0 +1,24 @@
+import { getMarketsFixture } from '../fixtures';
+import { MarketsService } from '../openapi/services/MarketsService';
+
+import { MarketsApi } from './MarketsApi';
+
+const markets = new MarketsApi();
+
+describe(MarketsApi.name, () => {
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('getMarkets', () => {
+    it('should get the current available markets', async () => {
+      const getMarketsSpy = vi
+        .spyOn(MarketsService, 'getAvailableMarkets')
+        .mockResolvedValue(getMarketsFixture);
+      const response = await markets.getMarkets();
+
+      expect(response).toEqual(getMarketsFixture.markets);
+      expect(getMarketsSpy).toHaveBeenCalledWith();
+    });
+  });
+});

--- a/src/apis/PersonalizationApi.test.ts
+++ b/src/apis/PersonalizationApi.test.ts
@@ -1,92 +1,88 @@
-import { type MockedClass } from 'vitest';
+import { type SpyInstance } from 'vitest';
 
 import { getMyTopArtistsFixture, getMyTopTracksFixture } from '../fixtures';
-import { Http } from '../helpers/Http';
+import { UsersService } from '../openapi/services/UsersService';
 
 import { PersonalizationApi } from './PersonalizationApi';
 
-vi.mock('../helpers/Http');
-
-const HttpMock = Http as MockedClass<typeof Http>;
-
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-function setup() {
-  const httpMock = new HttpMock('token');
-  const personalization = new PersonalizationApi();
-
-  return { httpMock, personalization };
-}
+const personalization = new PersonalizationApi();
 
 describe('PersonalizationApi', () => {
-  beforeEach(() => {
+  afterEach(() => {
     vi.resetAllMocks();
   });
 
   describe('getMyTopArtists', () => {
+    let getMyTopArtistsSpy: SpyInstance;
     beforeEach(() => {
-      HttpMock.prototype.get.mockResolvedValue(getMyTopArtistsFixture);
+      getMyTopArtistsSpy = vi
+        .spyOn(UsersService, 'getUsersTopArtistsAndTracks')
+        .mockResolvedValue(getMyTopArtistsFixture);
     });
 
-    it.todo(
-      "should get the current user's top artists (without options)",
-      async () => {
-        const { httpMock, personalization } = setup();
+    it("should get the current user's top artists (without options)", async () => {
+      const response = await personalization.getMyTopArtists();
 
-        const response = await personalization.getMyTopArtists();
+      expect(response).toEqual(getMyTopArtistsFixture);
+      expect(getMyTopArtistsSpy).toHaveBeenCalledWith(
+        'artists',
+        undefined,
+        undefined,
+        undefined,
+      );
+    });
 
-        expect(response).toEqual(getMyTopArtistsFixture);
-        expect(httpMock.get).toHaveBeenCalledWith('/me/top/artists', undefined);
-      },
-    );
+    it("should get the current user's top artists (with options)", async () => {
+      const response = await personalization.getMyTopArtists({
+        limit: 1,
+        offset: 2,
+        time_range: 'long_term',
+      });
 
-    it.todo(
-      "should get the current user's top artists (with options)",
-      async () => {
-        const { httpMock, personalization } = setup();
-
-        const response = await personalization.getMyTopArtists({ limit: 2 });
-
-        expect(response).toEqual(getMyTopArtistsFixture);
-        expect(httpMock.get).toHaveBeenCalledWith('/me/top/artists', {
-          params: {
-            limit: 2,
-          },
-        });
-      },
-    );
+      expect(response).toEqual(getMyTopArtistsFixture);
+      expect(getMyTopArtistsSpy).toHaveBeenCalledWith(
+        'artists',
+        'long_term',
+        1,
+        2,
+      );
+    });
   });
 
   describe('getMyTopTracks', () => {
+    let getMyTopTracksSpy: SpyInstance;
     beforeEach(() => {
-      HttpMock.prototype.get.mockResolvedValue(getMyTopTracksFixture);
+      getMyTopTracksSpy = vi
+        .spyOn(UsersService, 'getUsersTopArtistsAndTracks')
+        .mockResolvedValue(getMyTopTracksFixture);
     });
 
-    it.todo(
-      "should get the current user's top tracks (without options)",
-      async () => {
-        const { httpMock, personalization } = setup();
+    it("should get the current user's top tracks (without options)", async () => {
+      const response = await personalization.getMyTopTracks();
 
-        const response = await personalization.getMyTopTracks();
+      expect(response).toEqual(getMyTopTracksFixture);
+      expect(getMyTopTracksSpy).toHaveBeenCalledWith(
+        'tracks',
+        undefined,
+        undefined,
+        undefined,
+      );
+    });
 
-        expect(response).toEqual(getMyTopTracksFixture);
-        expect(httpMock.get).toHaveBeenCalledWith('/me/top/tracks', undefined);
-      },
-    );
+    it("should get the current user's top tracks (with options)", async () => {
+      const response = await personalization.getMyTopTracks({
+        limit: 1,
+        offset: 2,
+        time_range: 'long_term',
+      });
 
-    it.todo(
-      "should get the current user's top tracks (with options)",
-      async () => {
-        const { httpMock, personalization } = setup();
-
-        const response = await personalization.getMyTopTracks({ limit: 2 });
-
-        expect(response).toEqual(getMyTopTracksFixture);
-        expect(httpMock.get).toHaveBeenCalledWith('/me/top/tracks', {
-          params: {
-            limit: 2,
-          },
-        });
-      },
-    );
+      expect(response).toEqual(getMyTopTracksFixture);
+      expect(getMyTopTracksSpy).toHaveBeenCalledWith(
+        'tracks',
+        'long_term',
+        1,
+        2,
+      );
+    });
   });
 });

--- a/src/apis/PersonalizationApi.ts
+++ b/src/apis/PersonalizationApi.ts
@@ -1,4 +1,8 @@
-import { UsersService } from '../openapi';
+import {
+  type PagingArtistObject,
+  type PagingTrackObject,
+  UsersService,
+} from '../openapi';
 import { type PersonalizationOptions } from '../types/SpotifyOptions';
 
 export class PersonalizationApi {
@@ -11,15 +15,13 @@ export class PersonalizationApi {
    */
   public async getMyTopArtists(
     options?: PersonalizationOptions,
-  ): Promise<
-    Awaited<ReturnType<typeof UsersService.getUsersTopArtistsAndTracks>>
-  > {
-    return await UsersService.getUsersTopArtistsAndTracks(
+  ): Promise<PagingArtistObject> {
+    return (await UsersService.getUsersTopArtistsAndTracks(
       'artists',
       options?.time_range,
       options?.limit,
       options?.offset,
-    );
+    )) as PagingArtistObject;
   }
 
   /**
@@ -31,14 +33,12 @@ export class PersonalizationApi {
    */
   public async getMyTopTracks(
     options?: PersonalizationOptions,
-  ): Promise<
-    Awaited<ReturnType<typeof UsersService.getUsersTopArtistsAndTracks>>
-  > {
-    return await UsersService.getUsersTopArtistsAndTracks(
+  ): Promise<PagingTrackObject> {
+    return (await UsersService.getUsersTopArtistsAndTracks(
       'tracks',
       options?.time_range,
       options?.limit,
       options?.offset,
-    );
+    )) as PagingTrackObject;
   }
 }

--- a/src/apis/PlayerApi.test.ts
+++ b/src/apis/PlayerApi.test.ts
@@ -1,481 +1,364 @@
-import { type MockedClass } from 'vitest';
+import { type SpyInstance } from 'vitest';
 
 import {
   currentlyPlayingContextFixture,
   currentlyPlayingFixture,
-  deviceFixture,
+  getMyDevicesFixture,
+  getQueueFixture,
   getRecentlyPlayedTracksFixture,
 } from '../fixtures';
-import { Http } from '../helpers/Http';
+import { PlayerService } from '../openapi/services/PlayerService';
 
 import { PlayerApi } from './PlayerApi';
 
-vi.mock('../helpers/Http');
-
-const HttpMock = Http as MockedClass<typeof Http>;
-
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-function setup() {
-  const httpMock = new HttpMock('token');
-  const player = new PlayerApi();
-
-  return { httpMock, player };
-}
+const player = new PlayerApi();
 
 describe('PlayerApi', () => {
-  beforeEach(() => {
+  afterEach(() => {
     vi.resetAllMocks();
   });
 
   describe('addToQueue', () => {
-    it.todo(
-      "should add an item to the user's playback queue (without options)",
-      async () => {
-        const { httpMock, player } = setup();
+    let addToQueueSpy: SpyInstance;
+    beforeEach(() => {
+      addToQueueSpy = vi
+        .spyOn(PlayerService, 'addToQueue')
+        .mockResolvedValue(undefined);
+    });
 
-        await player.addToQueue('foo');
+    it("should add an item to the user's playback queue (without options)", async () => {
+      await player.addToQueue('foo');
 
-        expect(httpMock.post).toHaveBeenCalledWith('/me/player/queue', {
-          params: {
-            uri: 'foo',
-          },
-        });
-      },
-    );
+      expect(addToQueueSpy).toHaveBeenCalledWith('foo', undefined);
+    });
 
-    it.todo(
-      "should add an item to the user's playback queue (with options)",
-      async () => {
-        const { httpMock, player } = setup();
+    it("should add an item to the user's playback queue (with options)", async () => {
+      await player.addToQueue('foo', { device_id: 'bar' });
 
-        await player.addToQueue('foo', { device_id: 'bar' });
+      expect(addToQueueSpy).toHaveBeenCalledWith('foo', 'bar');
+    });
+  });
 
-        expect(httpMock.post).toHaveBeenCalledWith('/me/player/queue', {
-          params: {
-            uri: 'foo',
-            device_id: 'bar',
-          },
-        });
-      },
-    );
+  describe('getQueue', () => {
+    it("should get the user's current queue", async () => {
+      const getQueueSpy = vi
+        .spyOn(PlayerService, 'getQueue')
+        .mockResolvedValue(getQueueFixture);
+      const response = await player.getQueue();
+
+      expect(response).toEqual(getQueueFixture);
+      expect(getQueueSpy).toHaveBeenCalledWith();
+    });
   });
 
   describe('getCurrentlyPlayingTrack', () => {
+    let getCurrentlyPlayingTrackSpy: SpyInstance;
     beforeEach(() => {
-      HttpMock.prototype.get.mockResolvedValue(currentlyPlayingFixture);
+      getCurrentlyPlayingTrackSpy = vi
+        .spyOn(PlayerService, 'getTheUsersCurrentlyPlayingTrack')
+        .mockResolvedValue(currentlyPlayingContextFixture);
     });
 
-    it.todo(
-      "should get the user's currently playing track (without options)",
-      async () => {
-        const { httpMock, player } = setup();
-
-        const response = await player.getCurrentlyPlayingTrack();
-
-        expect(response).toEqual(currentlyPlayingFixture);
-        expect(httpMock.get).toHaveBeenCalledWith(
-          '/me/player/currently-playing',
-          undefined,
-        );
-      },
-    );
-
-    it.todo(
-      "should get the user's currently playing track (with options)",
-      async () => {
-        const { httpMock, player } = setup();
-
-        const response = await player.getCurrentlyPlayingTrack({
-          market: 'foo',
-        });
-
-        expect(response).toEqual(currentlyPlayingFixture);
-        expect(httpMock.get).toHaveBeenCalledWith(
-          '/me/player/currently-playing',
-          {
-            params: {
-              market: 'foo',
-            },
-          },
-        );
-      },
-    );
-  });
-
-  describe('getMyDevices', () => {
-    beforeEach(() => {
-      HttpMock.prototype.get.mockResolvedValue([deviceFixture]);
-    });
-
-    it.todo("should get a user's available devices", async () => {
-      const { httpMock, player } = setup();
-
-      const response = await player.getMyDevices();
-
-      expect(response).toEqual([deviceFixture]);
-      expect(httpMock.get).toHaveBeenCalledWith('/me/player/devices');
-    });
-  });
-
-  describe('getPlaybackInfo', () => {
-    beforeEach(() => {
-      HttpMock.prototype.get.mockResolvedValue(currentlyPlayingContextFixture);
-    });
-
-    it.todo(
-      "should get information about the user's current playback state (without options)",
-      async () => {
-        const { httpMock, player } = setup();
-
-        const response = await player.getPlaybackInfo();
-
-        expect(response).toEqual(currentlyPlayingContextFixture);
-        expect(httpMock.get).toHaveBeenCalledWith('/me/player', undefined);
-      },
-    );
-
-    it.todo(
-      "should get information about the user's current playback state (with options)",
-      async () => {
-        const { httpMock, player } = setup();
-
-        const response = await player.getPlaybackInfo({ market: 'foo' });
-
-        expect(response).toEqual(currentlyPlayingContextFixture);
-        expect(httpMock.get).toHaveBeenCalledWith('/me/player', {
-          params: {
-            market: 'foo',
-          },
-        });
-      },
-    );
-  });
-
-  describe('getRecentlyPlayedTracks', () => {
-    beforeEach(() => {
-      HttpMock.prototype.get.mockResolvedValue(getRecentlyPlayedTracksFixture);
-    });
-
-    it.todo(
-      "should get the current user's recently played tracks (without options)",
-      async () => {
-        const { httpMock, player } = setup();
-
-        const response = await player.getRecentlyPlayedTracks();
-
-        expect(response).toEqual(getRecentlyPlayedTracksFixture);
-        expect(httpMock.get).toHaveBeenCalledWith(
-          '/me/player/recently-played',
-          undefined,
-        );
-      },
-    );
-
-    it.todo(
-      "should get the current user's recently played tracks (with options)",
-      async () => {
-        const { httpMock, player } = setup();
-
-        const response = await player.getRecentlyPlayedTracks({ limit: 2 });
-
-        expect(response).toEqual(getRecentlyPlayedTracksFixture);
-        expect(httpMock.get).toHaveBeenCalledWith(
-          '/me/player/recently-played',
-          {
-            params: {
-              limit: 2,
-            },
-          },
-        );
-      },
-    );
-  });
-
-  describe('pause', () => {
-    it.todo("should pause a user's playback (without options)", async () => {
-      const { httpMock, player } = setup();
-
-      await player.pause();
-
-      expect(httpMock.put).toHaveBeenCalledWith('/me/player/pause', undefined);
-    });
-
-    it.todo("should pause a user's playback (with options)", async () => {
-      const { httpMock, player } = setup();
-
-      await player.pause({ device_id: 'foo' });
-
-      expect(httpMock.put).toHaveBeenCalledWith('/me/player/pause', {
-        params: {
-          device_id: 'foo',
-        },
-      });
-    });
-  });
-
-  describe('play', () => {
-    it.todo(
-      "should start or resume a user's playback (without options)",
-      async () => {
-        const { httpMock, player } = setup();
-
-        await player.play();
-
-        expect(httpMock.put).toHaveBeenCalledWith('/me/player/play', undefined);
-      },
-    );
-
-    it.todo(
-      "should start or resume a user's playback (with only query params)",
-      async () => {
-        const { httpMock, player } = setup();
-
-        await player.play({ device_id: 'foo' });
-
-        expect(httpMock.put).toHaveBeenCalledWith('/me/player/play', {
-          params: {
-            device_id: 'foo',
-          },
-        });
-      },
-    );
-
-    it.todo(
-      "should start or resume a user's playback (with only body params)",
-      async () => {
-        const { httpMock, player } = setup();
-
-        await player.play({ context_uri: 'foo' });
-
-        expect(httpMock.put).toHaveBeenCalledWith('/me/player/play', {
-          data: {
-            context_uri: 'foo',
-          },
-        });
-      },
-    );
-
-    it.todo(
-      "should start or resume a user's playback (with query and body params)",
-      async () => {
-        const { httpMock, player } = setup();
-
-        await player.play({ device_id: 'foo', context_uri: 'bar' });
-
-        expect(httpMock.put).toHaveBeenCalledWith('/me/player/play', {
-          params: {
-            device_id: 'foo',
-          },
-          data: {
-            context_uri: 'bar',
-          },
-        });
-      },
-    );
-  });
-
-  describe('seek', () => {
-    it.todo(
-      'should seek to a position in the currently playing track (without options)',
-      async () => {
-        const { httpMock, player } = setup();
-
-        await player.seek(100);
-
-        expect(httpMock.put).toHaveBeenCalledWith('/me/player/seek', {
-          params: {
-            position_ms: 100,
-          },
-        });
-      },
-    );
-
-    it.todo(
-      'should seek to a position in the currently playing track (with options)',
-      async () => {
-        const { httpMock, player } = setup();
-
-        await player.seek(100, { device_id: 'foo' });
-
-        expect(httpMock.put).toHaveBeenCalledWith('/me/player/seek', {
-          params: {
-            position_ms: 100,
-            device_id: 'foo',
-          },
-        });
-      },
-    );
-  });
-
-  describe('setRepeat', () => {
-    it.todo(
-      "should set the repeat mode for the user's playback (without options)",
-      async () => {
-        const { httpMock, player } = setup();
-
-        await player.setRepeat('track');
-
-        expect(httpMock.put).toHaveBeenCalledWith('/me/player/repeat', {
-          params: {
-            state: 'track',
-          },
-        });
-      },
-    );
-
-    it.todo(
-      "should set the repeat mode for the user's playback (with options)",
-      async () => {
-        const { httpMock, player } = setup();
-
-        await player.setRepeat('track', { device_id: 'foo' });
-
-        expect(httpMock.put).toHaveBeenCalledWith('/me/player/repeat', {
-          params: {
-            state: 'track',
-            device_id: 'foo',
-          },
-        });
-      },
-    );
-  });
-
-  describe('setShuffle', () => {
-    it.todo(
-      "should set the shuffle mode for the user's playback (without options)",
-      async () => {
-        const { httpMock, player } = setup();
-
-        await player.setShuffle(true);
-
-        expect(httpMock.put).toHaveBeenCalledWith('/me/player/shuffle', {
-          params: {
-            state: true,
-          },
-        });
-      },
-    );
-
-    it.todo(
-      "should set the shuffle mode for the user's playback (with options)",
-      async () => {
-        const { httpMock, player } = setup();
-
-        await player.setShuffle(true, { device_id: 'foo' });
-
-        expect(httpMock.put).toHaveBeenCalledWith('/me/player/shuffle', {
-          params: {
-            state: true,
-            device_id: 'foo',
-          },
-        });
-      },
-    );
-  });
-
-  describe('setVolume', () => {
-    it.todo(
-      "should set the volume for the user's current playback (without options)",
-      async () => {
-        const { httpMock, player } = setup();
-
-        await player.setVolume(50);
-
-        expect(httpMock.put).toHaveBeenCalledWith('/me/player/volume', {
-          params: {
-            volume_percent: 50,
-          },
-        });
-      },
-    );
-
-    it.todo(
-      "should set the volume for the user's current playback (with options)",
-      async () => {
-        const { httpMock, player } = setup();
-
-        await player.setVolume(50, { device_id: 'foo' });
-
-        expect(httpMock.put).toHaveBeenCalledWith('/me/player/volume', {
-          params: {
-            volume_percent: 50,
-            device_id: 'foo',
-          },
-        });
-      },
-    );
-  });
-
-  describe('skipToNext', () => {
-    it.todo('should skip to the next track (without options)', async () => {
-      const { httpMock, player } = setup();
-
-      await player.skipToNext();
-
-      expect(httpMock.post).toHaveBeenCalledWith('/me/player/next', undefined);
-    });
-
-    it.todo('should skip to the next track (with options)', async () => {
-      const { httpMock, player } = setup();
-
-      await player.skipToNext({ device_id: 'foo' });
-
-      expect(httpMock.post).toHaveBeenCalledWith('/me/player/next', {
-        params: {
-          device_id: 'foo',
-        },
-      });
-    });
-  });
-
-  describe('skipToPrevious', () => {
-    it.todo('should skip to the previous track (without options)', async () => {
-      const { httpMock, player } = setup();
-
-      await player.skipToPrevious();
-
-      expect(httpMock.post).toHaveBeenCalledWith(
-        '/me/player/previous',
+    it("should get the user's currently playing track (without options)", async () => {
+      const response = await player.getCurrentlyPlayingTrack();
+
+      expect(response).toEqual(currentlyPlayingContextFixture);
+      expect(getCurrentlyPlayingTrackSpy).toHaveBeenCalledWith(
+        undefined,
         undefined,
       );
     });
 
-    it.todo('should skip to the previous track (with options)', async () => {
-      const { httpMock, player } = setup();
+    it("should get the user's currently playing track (with options)", async () => {
+      const response = await player.getCurrentlyPlayingTrack({
+        market: 'foo',
+        additional_types: ['episode'],
+      });
 
-      await player.skipToPrevious({ device_id: 'foo' });
+      expect(response).toEqual(currentlyPlayingContextFixture);
+      expect(getCurrentlyPlayingTrackSpy).toHaveBeenCalledWith(
+        'foo',
+        'episode',
+      );
+    });
+  });
 
-      expect(httpMock.post).toHaveBeenCalledWith('/me/player/previous', {
-        params: {
-          device_id: 'foo',
-        },
+  describe('getMyDevices', () => {
+    it("should get a user's available devices", async () => {
+      const getMyDevicesSpy = vi
+        .spyOn(PlayerService, 'getAUsersAvailableDevices')
+        .mockResolvedValue(getMyDevicesFixture);
+      const response = await player.getMyDevices();
+
+      expect(response).toEqual(getMyDevicesFixture.devices);
+      expect(getMyDevicesSpy).toHaveBeenCalledWith();
+    });
+  });
+
+  describe('getPlaybackInfo', () => {
+    let getPlaybackInfoSpy: SpyInstance;
+    beforeEach(() => {
+      getPlaybackInfoSpy = vi
+        .spyOn(PlayerService, 'getInformationAboutTheUsersCurrentPlayback')
+        .mockResolvedValue(currentlyPlayingFixture);
+    });
+
+    it("should get information about the user's current playback state (without options)", async () => {
+      const response = await player.getPlaybackInfo();
+
+      expect(response).toEqual(currentlyPlayingFixture);
+      expect(getPlaybackInfoSpy).toHaveBeenCalledWith(undefined, undefined);
+    });
+
+    it("should get information about the user's current playback state (with options)", async () => {
+      const response = await player.getPlaybackInfo({
+        market: 'foo',
+        additional_types: ['episode'],
+      });
+
+      expect(response).toEqual(currentlyPlayingFixture);
+      expect(getPlaybackInfoSpy).toHaveBeenCalledWith('foo', 'episode');
+    });
+  });
+
+  describe('getRecentlyPlayedTracks', () => {
+    let getRecentlyPlayedTracksSpy: SpyInstance;
+    beforeEach(() => {
+      getRecentlyPlayedTracksSpy = vi
+        .spyOn(PlayerService, 'getRecentlyPlayed')
+        .mockResolvedValue(getRecentlyPlayedTracksFixture);
+    });
+
+    it("should get the current user's recently played tracks (without options)", async () => {
+      const response = await player.getRecentlyPlayedTracks();
+
+      expect(response).toEqual(getRecentlyPlayedTracksFixture);
+      expect(getRecentlyPlayedTracksSpy).toHaveBeenCalledWith(
+        undefined,
+        undefined,
+        undefined,
+      );
+    });
+
+    it("should get the current user's recently played tracks (with options)", async () => {
+      const response = await player.getRecentlyPlayedTracks({
+        limit: 1,
+        after: 2,
+        before: 3,
+      });
+
+      expect(response).toEqual(getRecentlyPlayedTracksFixture);
+      expect(getRecentlyPlayedTracksSpy).toHaveBeenCalledWith(1, 2, 3);
+    });
+  });
+
+  describe('pause', () => {
+    let pauseSpy: SpyInstance;
+    beforeEach(() => {
+      pauseSpy = vi
+        .spyOn(PlayerService, 'pauseAUsersPlayback')
+        .mockResolvedValue(undefined);
+    });
+
+    it("should pause a user's playback (without options)", async () => {
+      await player.pause();
+
+      expect(pauseSpy).toHaveBeenCalledWith(undefined);
+    });
+
+    it("should pause a user's playback (with options)", async () => {
+      await player.pause({ device_id: 'foo' });
+
+      expect(pauseSpy).toHaveBeenCalledWith('foo');
+    });
+  });
+
+  describe('play', () => {
+    let playSpy: SpyInstance;
+    beforeEach(() => {
+      playSpy = vi
+        .spyOn(PlayerService, 'startAUsersPlayback')
+        .mockResolvedValue(undefined);
+    });
+
+    it("should start or resume a user's playback (without options)", async () => {
+      await player.play();
+
+      expect(playSpy).toHaveBeenCalledWith(undefined, {});
+    });
+
+    it("should start or resume a user's playback (with only query params)", async () => {
+      await player.play({ device_id: 'foo' });
+
+      expect(playSpy).toHaveBeenCalledWith('foo', {});
+    });
+
+    it("should start or resume a user's playback (with only body params)", async () => {
+      await player.play({ context_uri: 'foo' });
+
+      expect(playSpy).toHaveBeenCalledWith(undefined, {
+        context_uri: 'foo',
+      });
+    });
+
+    it("should start or resume a user's playback (with query and body params)", async () => {
+      await player.play({ device_id: 'foo', context_uri: 'bar' });
+
+      expect(playSpy).toHaveBeenCalledWith('foo', {
+        context_uri: 'bar',
       });
     });
   });
 
-  describe('transferPlayback', () => {
-    it.todo("should transfer a user's playback (without options)", async () => {
-      const { httpMock, player } = setup();
+  describe('seek', () => {
+    let seekSpy: SpyInstance;
+    beforeEach(() => {
+      seekSpy = vi
+        .spyOn(PlayerService, 'seekToPositionInCurrentlyPlayingTrack')
+        .mockResolvedValue(undefined);
+    });
 
+    it('should seek to a position in the currently playing track (without options)', async () => {
+      await player.seek(100);
+
+      expect(seekSpy).toHaveBeenCalledWith(100, undefined);
+    });
+
+    it('should seek to a position in the currently playing track (with options)', async () => {
+      await player.seek(100, { device_id: 'foo' });
+
+      expect(seekSpy).toHaveBeenCalledWith(100, 'foo');
+    });
+  });
+
+  describe('setRepeat', () => {
+    let setRepeatSpy: SpyInstance;
+    beforeEach(() => {
+      setRepeatSpy = vi
+        .spyOn(PlayerService, 'setRepeatModeOnUsersPlayback')
+        .mockResolvedValue(undefined);
+    });
+
+    it("should set the repeat mode for the user's playback (without options)", async () => {
+      await player.setRepeat('track');
+
+      expect(setRepeatSpy).toHaveBeenCalledWith('track', undefined);
+    });
+
+    it("should set the repeat mode for the user's playback (with options)", async () => {
+      await player.setRepeat('track', { device_id: 'foo' });
+
+      expect(setRepeatSpy).toHaveBeenCalledWith('track', 'foo');
+    });
+  });
+
+  describe('setShuffle', () => {
+    let setShuffleSpy: SpyInstance;
+    beforeEach(() => {
+      setShuffleSpy = vi
+        .spyOn(PlayerService, 'toggleShuffleForUsersPlayback')
+        .mockResolvedValue(undefined);
+    });
+
+    it("should set the shuffle mode for the user's playback (without options)", async () => {
+      await player.setShuffle(true);
+
+      expect(setShuffleSpy).toHaveBeenCalledWith(true, undefined);
+    });
+
+    it("should set the shuffle mode for the user's playback (with options)", async () => {
+      await player.setShuffle(true, { device_id: 'foo' });
+
+      expect(setShuffleSpy).toHaveBeenCalledWith(true, 'foo');
+    });
+  });
+
+  describe('setVolume', () => {
+    let setVolumeSpy: SpyInstance;
+    beforeEach(() => {
+      setVolumeSpy = vi
+        .spyOn(PlayerService, 'setVolumeForUsersPlayback')
+        .mockResolvedValue(undefined);
+    });
+
+    it("should set the volume for the user's current playback (without options)", async () => {
+      await player.setVolume(50);
+
+      expect(setVolumeSpy).toHaveBeenCalledWith(50, undefined);
+    });
+
+    it("should set the volume for the user's current playback (with options)", async () => {
+      await player.setVolume(50, { device_id: 'foo' });
+
+      expect(setVolumeSpy).toHaveBeenCalledWith(50, 'foo');
+    });
+  });
+
+  describe('skipToNext', () => {
+    let skipToNextSpy: SpyInstance;
+    beforeEach(() => {
+      skipToNextSpy = vi
+        .spyOn(PlayerService, 'skipUsersPlaybackToNextTrack')
+        .mockResolvedValue(undefined);
+    });
+
+    it('should skip to the next track (without options)', async () => {
+      await player.skipToNext();
+
+      expect(skipToNextSpy).toHaveBeenCalledWith(undefined);
+    });
+
+    it('should skip to the next track (with options)', async () => {
+      await player.skipToNext({ device_id: 'foo' });
+
+      expect(skipToNextSpy).toHaveBeenCalledWith('foo');
+    });
+  });
+
+  describe('skipToPrevious', () => {
+    let skipToPreviousSpy: SpyInstance;
+    beforeEach(() => {
+      skipToPreviousSpy = vi
+        .spyOn(PlayerService, 'skipUsersPlaybackToPreviousTrack')
+        .mockResolvedValue(undefined);
+    });
+
+    it('should skip to the previous track (without options)', async () => {
+      await player.skipToPrevious();
+
+      expect(skipToPreviousSpy).toHaveBeenCalledWith(undefined);
+    });
+
+    it('should skip to the previous track (with options)', async () => {
+      await player.skipToPrevious({ device_id: 'foo' });
+
+      expect(skipToPreviousSpy).toHaveBeenCalledWith('foo');
+    });
+  });
+
+  describe('transferPlayback', () => {
+    let transferPlaybackSpy: SpyInstance;
+    beforeEach(() => {
+      transferPlaybackSpy = vi
+        .spyOn(PlayerService, 'transferAUsersPlayback')
+        .mockResolvedValue(undefined);
+    });
+
+    it("should transfer a user's playback (without options)", async () => {
       await player.transferPlayback('foo');
 
-      expect(httpMock.put).toHaveBeenCalledWith('/me/player', {
-        data: {
-          device_ids: ['foo'],
-        },
+      expect(transferPlaybackSpy).toHaveBeenCalledWith({
+        device_ids: ['foo'],
+        play: undefined,
       });
     });
 
-    it.todo("should transfer a user's playback (with options)", async () => {
-      const { httpMock, player } = setup();
-
+    it("should transfer a user's playback (with options)", async () => {
       await player.transferPlayback('foo', { play: true });
 
-      expect(httpMock.put).toHaveBeenCalledWith('/me/player', {
-        data: {
-          device_ids: ['foo'],
-          play: true,
-        },
+      expect(transferPlaybackSpy).toHaveBeenCalledWith({
+        device_ids: ['foo'],
+        play: true,
       });
     });
   });

--- a/src/apis/PlaylistsApi.test.ts
+++ b/src/apis/PlaylistsApi.test.ts
@@ -1,5 +1,6 @@
-import { type MockedClass } from 'vitest';
+import { type SpyInstance } from 'vitest';
 
+import { PlaylistsService } from '../openapi';
 import {
   getMyPlaylistsFixture,
   getPlaylistItemsFixture,
@@ -8,85 +9,59 @@ import {
   snapshotIdFixture,
   spotifyImageFixture,
 } from '../fixtures';
-import { Http } from '../helpers/Http';
 
 import { PlaylistsApi } from './PlaylistsApi';
 
-vi.mock('../helpers/Http');
-
-const HttpMock = Http as MockedClass<typeof Http>;
-
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-function setup() {
-  const httpMock = new HttpMock('token');
-  const playlists = new PlaylistsApi();
-
-  return { httpMock, playlists };
-}
+const playlists = new PlaylistsApi();
 
 describe('PlaylistsApi', () => {
-  beforeEach(() => {
+  afterEach(() => {
     vi.resetAllMocks();
   });
 
-  describe('addItemToPlaylist', () => {
+  describe('addItemsToPlaylist', () => {
+    let addItemsToPlaylistSpy: SpyInstance;
     beforeEach(() => {
-      HttpMock.prototype.post.mockResolvedValue(snapshotIdFixture);
+      addItemsToPlaylistSpy = vi
+        .spyOn(PlaylistsService, 'addTracksToPlaylist')
+        .mockResolvedValue(snapshotIdFixture);
     });
 
-    it.todo('should add an item to a playlist (without options)', async () => {
-      const { httpMock, playlists } = setup();
-
+    it('should add an item to a playlist (without options)', async () => {
       const response = await playlists.addItemToPlaylist('foo', 'bar');
 
       expect(response).toBe(snapshotIdFixture.snapshot_id);
-      expect(httpMock.post).toHaveBeenCalledWith('/playlists/foo/tracks', {
-        data: {
-          uris: ['bar'],
-        },
-      });
+      expect(addItemsToPlaylistSpy).toHaveBeenCalledWith(
+        'foo',
+        undefined,
+        'bar',
+      );
     });
 
-    it.todo('should add an item to a playlist (with options)', async () => {
-      const { httpMock, playlists } = setup();
-
+    it('should add an item to a playlist (with options)', async () => {
       const response = await playlists.addItemToPlaylist('foo', 'bar', {
         position: 2,
       });
 
       expect(response).toBe(snapshotIdFixture.snapshot_id);
-      expect(httpMock.post).toHaveBeenCalledWith('/playlists/foo/tracks', {
-        data: {
-          uris: ['bar'],
-          position: 2,
-        },
-      });
-    });
-  });
-  describe('addItemsToPlaylist', () => {
-    beforeEach(() => {
-      HttpMock.prototype.post.mockResolvedValue(snapshotIdFixture);
+      expect(addItemsToPlaylistSpy).toHaveBeenCalledWith('foo', 2, 'bar');
     });
 
-    it.todo('should add items to a playlist (without options)', async () => {
-      const { httpMock, playlists } = setup();
-
+    it('should add items to a playlist (without options)', async () => {
       const response = await playlists.addItemsToPlaylist('foo', [
         'bar',
         'baz',
       ]);
 
       expect(response).toBe(snapshotIdFixture.snapshot_id);
-      expect(httpMock.post).toHaveBeenCalledWith('/playlists/foo/tracks', {
-        data: {
-          uris: ['bar', 'baz'],
-        },
-      });
+      expect(addItemsToPlaylistSpy).toHaveBeenCalledWith(
+        'foo',
+        undefined,
+        'bar,baz',
+      );
     });
 
-    it.todo('should add items to a playlist (with options)', async () => {
-      const { httpMock, playlists } = setup();
-
+    it('should add items to a playlist (with options)', async () => {
       const response = await playlists.addItemsToPlaylist(
         'foo',
         ['bar', 'baz'],
@@ -94,311 +69,291 @@ describe('PlaylistsApi', () => {
       );
 
       expect(response).toBe(snapshotIdFixture.snapshot_id);
-      expect(httpMock.post).toHaveBeenCalledWith('/playlists/foo/tracks', {
-        data: {
-          uris: ['bar', 'baz'],
-          position: 2,
-        },
-      });
+      expect(addItemsToPlaylistSpy).toHaveBeenCalledWith('foo', 2, 'bar,baz');
     });
   });
 
   describe('changePlaylistDetails', () => {
-    it.todo("should change a playlist's details", async () => {
-      const { httpMock, playlists } = setup();
+    it("should change a playlist's details", async () => {
+      const changePlaylistDetailsSpy = vi
+        .spyOn(PlaylistsService, 'changePlaylistDetails')
+        .mockResolvedValue(undefined);
 
-      await playlists.changePlaylistDetails('foo', { description: 'bar' });
+      await playlists.changePlaylistDetails('foo', {
+        description: 'bar',
+        collaborative: false,
+        public: true,
+        name: 'baz',
+      });
 
-      expect(httpMock.put).toHaveBeenCalledWith('/playlists/foo', {
-        data: {
-          description: 'bar',
-        },
+      expect(changePlaylistDetailsSpy).toHaveBeenCalledWith('foo', {
+        description: 'bar',
+        collaborative: false,
+        public: true,
+        name: 'baz',
       });
     });
   });
 
   describe('createPlaylist', () => {
+    let createPlaylistSpy: SpyInstance;
     beforeEach(() => {
-      HttpMock.prototype.post.mockResolvedValue(playlistFixture);
+      createPlaylistSpy = vi
+        .spyOn(PlaylistsService, 'createPlaylist')
+        .mockResolvedValue(playlistFixture);
     });
 
-    it.todo('should create a playlist (without options)', async () => {
-      const { httpMock, playlists } = setup();
-
+    it('should create a playlist (without options)', async () => {
       const response = await playlists.createPlaylist('foo', 'bar');
 
       expect(response).toEqual(playlistFixture);
-      expect(httpMock.post).toHaveBeenCalledWith('/users/foo/playlists', {
-        data: {
-          name: 'bar',
-        },
+      expect(createPlaylistSpy).toHaveBeenCalledWith('foo', {
+        name: 'bar',
       });
     });
 
-    it.todo('should create a playlist (with options)', async () => {
-      const { httpMock, playlists } = setup();
-
+    it('should create a playlist (with options)', async () => {
       const response = await playlists.createPlaylist('foo', 'bar', {
         description: 'baz',
+        collaborative: false,
+        public: true,
       });
 
       expect(response).toEqual(playlistFixture);
-      expect(httpMock.post).toHaveBeenCalledWith('/users/foo/playlists', {
-        data: {
-          name: 'bar',
-          description: 'baz',
-        },
+      expect(createPlaylistSpy).toHaveBeenCalledWith('foo', {
+        name: 'bar',
+        description: 'baz',
+        collaborative: false,
+        public: true,
       });
     });
   });
 
   describe('getMyPlaylists', () => {
+    let getMyPlaylistsSpy: SpyInstance;
     beforeEach(() => {
-      HttpMock.prototype.get.mockResolvedValue(getMyPlaylistsFixture);
+      getMyPlaylistsSpy = vi
+        .spyOn(PlaylistsService, 'getAListOfCurrentUsersPlaylists')
+        .mockResolvedValue(getMyPlaylistsFixture);
     });
 
-    it.todo(
-      "should get a list of the current user's playlists (without options)",
-      async () => {
-        const { httpMock, playlists } = setup();
+    it("should get a list of the current user's playlists (without options)", async () => {
+      const response = await playlists.getMyPlaylists();
 
-        const response = await playlists.getMyPlaylists();
+      expect(response).toEqual(getMyPlaylistsFixture);
+      expect(getMyPlaylistsSpy).toHaveBeenCalledWith(undefined, undefined);
+    });
 
-        expect(response).toEqual(getMyPlaylistsFixture);
-        expect(httpMock.get).toHaveBeenCalledWith('/me/playlists', undefined);
-      },
-    );
+    it("should get a list of the current user's playlists (with options)", async () => {
+      const response = await playlists.getMyPlaylists({ limit: 1, offset: 2 });
 
-    it.todo(
-      "should get a list of the current user's playlists (with options)",
-      async () => {
-        const { httpMock, playlists } = setup();
-
-        const response = await playlists.getMyPlaylists({ limit: 2 });
-
-        expect(response).toEqual(getMyPlaylistsFixture);
-        expect(httpMock.get).toHaveBeenCalledWith('/me/playlists', {
-          params: {
-            limit: 2,
-          },
-        });
-      },
-    );
+      expect(response).toEqual(getMyPlaylistsFixture);
+      expect(getMyPlaylistsSpy).toHaveBeenCalledWith(1, 2);
+    });
   });
 
   describe('getPlaylist', () => {
+    let getPlaylistSpy: SpyInstance;
     beforeEach(() => {
-      HttpMock.prototype.get.mockResolvedValue(playlistFixture);
+      getPlaylistSpy = vi
+        .spyOn(PlaylistsService, 'getPlaylist')
+        .mockResolvedValue(playlistFixture);
     });
 
-    it.todo('should get a playlist (without options)', async () => {
-      const { httpMock, playlists } = setup();
-
+    it('should get a playlist (without options)', async () => {
       const response = await playlists.getPlaylist('foo');
 
       expect(response).toEqual(playlistFixture);
-      expect(httpMock.get).toHaveBeenCalledWith('/playlists/foo', undefined);
-    });
-
-    it.todo('should get a playlist (with options)', async () => {
-      const { httpMock, playlists } = setup();
-
-      const response = await playlists.getPlaylist('foo', { market: 'bar' });
-
-      expect(response).toEqual(playlistFixture);
-      expect(httpMock.get).toHaveBeenCalledWith('/playlists/foo', {
-        params: {
-          market: 'bar',
-        },
-      });
-    });
-  });
-
-  describe('getPlaylistCover', () => {
-    beforeEach(() => {
-      HttpMock.prototype.get.mockResolvedValue([spotifyImageFixture]);
-    });
-
-    it.todo('should get a playlist cover image', async () => {
-      const { httpMock, playlists } = setup();
-
-      const response = await playlists.getPlaylistCover('foo');
-
-      expect(response).toEqual([spotifyImageFixture]);
-      expect(httpMock.get).toHaveBeenCalledWith('/playlists/foo/images');
-    });
-  });
-
-  describe('getPlaylistItems', () => {
-    beforeEach(() => {
-      HttpMock.prototype.get.mockResolvedValue(getPlaylistItemsFixture);
-    });
-
-    it.todo("should get a playlist's items (without options)", async () => {
-      const { httpMock, playlists } = setup();
-
-      const response = await playlists.getPlaylistItems('foo');
-
-      expect(response).toEqual(getPlaylistItemsFixture);
-      expect(httpMock.get).toHaveBeenCalledWith(
-        '/playlists/foo/tracks',
+      expect(getPlaylistSpy).toHaveBeenCalledWith(
+        'foo',
+        undefined,
+        undefined,
         undefined,
       );
     });
 
-    it.todo("should get a playlist's items (with options)", async () => {
-      const { httpMock, playlists } = setup();
+    it('should get a playlist (with options)', async () => {
+      const response = await playlists.getPlaylist('foo', {
+        market: 'bar',
+        fields: 'baz',
+        additional_types: ['episode'],
+      });
 
-      const response = await playlists.getPlaylistItems('foo', { limit: 2 });
+      expect(response).toEqual(playlistFixture);
+      expect(getPlaylistSpy).toHaveBeenCalledWith(
+        'foo',
+        'bar',
+        'baz',
+        'episode',
+      );
+    });
+  });
+
+  describe('getPlaylistCover', () => {
+    it.todo('should get a playlist cover image', async () => {
+      // const getPlaylistCoverSpy = vi
+      //   .spyOn(PlaylistsService, 'getPlaylistCover')
+      //   .mockResolvedValue(getPlaylistCoverFixture);
+      const response = await playlists.getPlaylistCover('foo');
+
+      expect(response).toEqual([spotifyImageFixture]);
+      expect(null).toHaveBeenCalledWith('/playlists/foo/images');
+    });
+  });
+
+  describe('getPlaylistItems', () => {
+    let getPlaylistItemsSpy: SpyInstance;
+    beforeEach(() => {
+      getPlaylistItemsSpy = vi
+        .spyOn(PlaylistsService, 'getPlaylistsTracks')
+        .mockResolvedValue(getPlaylistItemsFixture);
+    });
+
+    it("should get a playlist's items (without options)", async () => {
+      const response = await playlists.getPlaylistItems('foo');
 
       expect(response).toEqual(getPlaylistItemsFixture);
-      expect(httpMock.get).toHaveBeenCalledWith('/playlists/foo/tracks', {
-        params: {
-          limit: 2,
-        },
+      expect(getPlaylistItemsSpy.mock.calls[0][0]).toBe('foo');
+    });
+
+    it("should get a playlist's items (with options)", async () => {
+      const response = await playlists.getPlaylistItems('foo', {
+        limit: 1,
+        offset: 2,
+        market: 'bar',
+        fields: 'baz',
+        additional_types: ['episode'],
       });
+
+      expect(response).toEqual(getPlaylistItemsFixture);
+      expect(getPlaylistItemsSpy).toHaveBeenCalledWith(
+        'foo',
+        'bar',
+        'baz',
+        1,
+        2,
+        'episode',
+      );
     });
   });
 
   describe('getUserPlaylists', () => {
+    let getUserPlaylistsSpy: SpyInstance;
     beforeEach(() => {
-      HttpMock.prototype.get.mockResolvedValue(getUserPlaylistsFixture);
+      getUserPlaylistsSpy = vi
+        .spyOn(PlaylistsService, 'getListUsersPlaylists')
+        .mockResolvedValue(getUserPlaylistsFixture);
     });
 
-    it.todo(
-      "should get a list of a user's playlists (without options)",
-      async () => {
-        const { httpMock, playlists } = setup();
+    it("should get a list of a user's playlists (without options)", async () => {
+      const response = await playlists.getUserPlaylists('foo');
 
-        const response = await playlists.getUserPlaylists('foo');
-
-        expect(response).toEqual(getUserPlaylistsFixture);
-        expect(httpMock.get).toHaveBeenCalledWith(
-          '/users/foo/playlists',
-          undefined,
-        );
-      },
-    );
-
-    it.todo(
-      "should get a list of a user's playlists (with options)",
-      async () => {
-        const { httpMock, playlists } = setup();
-
-        const response = await playlists.getUserPlaylists('foo', { limit: 2 });
-
-        expect(response).toEqual(getUserPlaylistsFixture);
-        expect(httpMock.get).toHaveBeenCalledWith('/users/foo/playlists', {
-          params: {
-            limit: 2,
-          },
-        });
-      },
-    );
-  });
-
-  describe('removePlaylistItem', () => {
-    beforeEach(() => {
-      HttpMock.prototype.delete.mockResolvedValue(snapshotIdFixture);
+      expect(response).toEqual(getUserPlaylistsFixture);
+      expect(getUserPlaylistsSpy).toHaveBeenCalledWith(
+        'foo',
+        undefined,
+        undefined,
+      );
     });
 
-    it.todo('should remove an item from a playlist', async () => {
-      const { httpMock, playlists } = setup();
-
-      const response = await playlists.removePlaylistItem('foo', 'bar');
-
-      expect(response).toBe(snapshotIdFixture.snapshot_id);
-      expect(httpMock.delete).toHaveBeenCalledWith('/playlists/foo/tracks', {
-        data: {
-          tracks: [{ uri: 'bar' }],
-        },
+    it("should get a list of a user's playlists (with options)", async () => {
+      const response = await playlists.getUserPlaylists('foo', {
+        limit: 1,
+        offset: 2,
       });
+
+      expect(response).toEqual(getUserPlaylistsFixture);
+      expect(getUserPlaylistsSpy).toHaveBeenCalledWith('foo', 1, 2);
     });
   });
 
   describe('removePlaylistItems', () => {
+    let removePlaylistsItemSpy: SpyInstance;
     beforeEach(() => {
-      HttpMock.prototype.delete.mockResolvedValue(snapshotIdFixture);
+      removePlaylistsItemSpy = vi
+        .spyOn(PlaylistsService, 'removeTracksPlaylist')
+        .mockResolvedValue(snapshotIdFixture);
     });
 
-    it.todo('should remove items from a playlist', async () => {
-      const { httpMock, playlists } = setup();
-
-      const response = await playlists.removePlaylistItems('foo', [
-        'bar',
-        'baz',
-      ]);
+    it('should remove an item from a playlist', async () => {
+      const response = await playlists.removePlaylistItem('foo', 'bar');
 
       expect(response).toBe(snapshotIdFixture.snapshot_id);
-      expect(httpMock.delete).toHaveBeenCalledWith('/playlists/foo/tracks', {
-        data: {
-          tracks: [{ uri: 'bar' }, { uri: 'baz' }],
-        },
+      expect(removePlaylistsItemSpy).toHaveBeenCalledWith('foo', {
+        tracks: [{ uri: 'bar' }],
+      });
+    });
+
+    it('should remove items from a playlist', async () => {
+      const response = await playlists.removePlaylistItems(
+        'foo',
+        ['bar', 'baz'],
+        'qux',
+      );
+
+      expect(response).toBe(snapshotIdFixture.snapshot_id);
+      expect(removePlaylistsItemSpy).toHaveBeenCalledWith('foo', {
+        tracks: [{ uri: 'bar' }, { uri: 'baz' }],
+        snapshot_id: 'qux',
       });
     });
   });
 
   describe('reorderPlaylistItems', () => {
+    let reorderPlaylistItemsSpy: SpyInstance;
     beforeEach(() => {
-      HttpMock.prototype.put.mockResolvedValue(snapshotIdFixture);
+      reorderPlaylistItemsSpy = vi
+        .spyOn(PlaylistsService, 'reorderOrReplacePlaylistsTracks')
+        .mockResolvedValue(snapshotIdFixture);
     });
 
-    it.todo("should reorder a playlist's items (without options)", async () => {
-      const { httpMock, playlists } = setup();
-
+    it("should reorder a playlist's items (without options)", async () => {
       const response = await playlists.reorderPlaylistItems('foo', 3, 2);
 
       expect(response).toBe(snapshotIdFixture.snapshot_id);
-      expect(httpMock.put).toHaveBeenCalledWith('/playlists/foo/tracks', {
-        data: {
-          range_start: 3,
-          insert_before: 2,
-        },
+      expect(reorderPlaylistItemsSpy).toHaveBeenCalledWith('foo', undefined, {
+        range_start: 3,
+        insert_before: 2,
+        range_length: undefined,
+        snapshot_id: undefined,
       });
     });
 
-    it.todo("should reorder a playlist's items (with options)", async () => {
-      const { httpMock, playlists } = setup();
-
+    it("should reorder a playlist's items (with options)", async () => {
       const response = await playlists.reorderPlaylistItems('foo', 3, 2, {
         snapshot_id: 'bar',
+        range_length: 4,
       });
 
       expect(response).toBe(snapshotIdFixture.snapshot_id);
-      expect(httpMock.put).toHaveBeenCalledWith('/playlists/foo/tracks', {
-        data: {
-          range_start: 3,
-          insert_before: 2,
-          snapshot_id: 'bar',
-        },
+      expect(reorderPlaylistItemsSpy).toHaveBeenCalledWith('foo', undefined, {
+        range_start: 3,
+        insert_before: 2,
+        snapshot_id: 'bar',
+        range_length: 4,
       });
     });
   });
 
   describe('replacePlaylistItems', () => {
-    it.todo("should replace a playlist's items", async () => {
-      const { httpMock, playlists } = setup();
-
+    it("should replace a playlist's items", async () => {
+      const replacePlaylistItemsSpy = vi
+        .spyOn(PlaylistsService, 'reorderOrReplacePlaylistsTracks')
+        .mockResolvedValue(snapshotIdFixture);
       await playlists.replacePlaylistItems('foo', ['bar', 'baz']);
 
-      expect(httpMock.put).toHaveBeenCalledWith('/playlists/foo/tracks', {
-        data: {
-          uris: ['bar', 'baz'],
-        },
-      });
+      expect(replacePlaylistItemsSpy).toHaveBeenCalledWith('foo', 'bar,baz');
     });
   });
 
   describe('uploadPlaylistCover', () => {
-    it.todo('should upload a custom playlist cover image', async () => {
-      const { httpMock, playlists } = setup();
-
+    it('should upload a custom playlist cover image', async () => {
+      const uploadPlaylistCoverSpy = vi
+        .spyOn(PlaylistsService, 'uploadCustomPlaylistCover')
+        .mockResolvedValue(snapshotIdFixture);
       await playlists.uploadPlaylistCover('foo', 'bar');
 
-      expect(httpMock.put).toHaveBeenCalledWith('/playlists/foo/images', {
-        data: 'bar',
-        contentType: 'image/jpeg',
-      });
+      expect(uploadPlaylistCoverSpy).toHaveBeenCalledWith('foo', 'bar');
     });
   });
 });

--- a/src/apis/PlaylistsApi.test.ts
+++ b/src/apis/PlaylistsApi.test.ts
@@ -3,11 +3,11 @@ import { type SpyInstance } from 'vitest';
 import { PlaylistsService } from '../openapi';
 import {
   getMyPlaylistsFixture,
+  getPlaylistCoverFixture,
   getPlaylistItemsFixture,
   getUserPlaylistsFixture,
   playlistFixture,
   snapshotIdFixture,
-  spotifyImageFixture,
 } from '../fixtures';
 
 import { PlaylistsApi } from './PlaylistsApi';
@@ -190,14 +190,14 @@ describe('PlaylistsApi', () => {
   });
 
   describe('getPlaylistCover', () => {
-    it.todo('should get a playlist cover image', async () => {
-      // const getPlaylistCoverSpy = vi
-      //   .spyOn(PlaylistsService, 'getPlaylistCover')
-      //   .mockResolvedValue(getPlaylistCoverFixture);
+    it('should get a playlist cover image', async () => {
+      const getPlaylistCoverSpy = vi
+        .spyOn(PlaylistsService, 'getPlaylistCover')
+        .mockResolvedValue(getPlaylistCoverFixture);
       const response = await playlists.getPlaylistCover('foo');
 
-      expect(response).toEqual([spotifyImageFixture]);
-      expect(null).toHaveBeenCalledWith('/playlists/foo/images');
+      expect(response).toEqual(getPlaylistCoverFixture);
+      expect(getPlaylistCoverSpy).toHaveBeenCalledWith('foo');
     });
   });
 

--- a/src/apis/SearchApi.test.ts
+++ b/src/apis/SearchApi.test.ts
@@ -1,255 +1,330 @@
-import { type MockedFunction } from 'vitest';
+import { type SpyInstance } from 'vitest';
 
 import {
   searchAlbumsFixture,
   searchArtistsFixture,
+  searchAudiobooksFixture,
   searchEpisodesFixture,
   searchFixture,
   searchPlaylistsFixture,
   searchShowsFixture,
   searchTracksFixture,
 } from '../fixtures';
-import { Http } from '../helpers/Http';
-import { searchHelper } from '../helpers/searchHelper';
+import { SearchService } from '../openapi/services/SearchService';
 
 import { SearchApi } from './SearchApi';
 
-vi.mock('../helpers/searchHelper');
+const search = new SearchApi();
 
-const searchHelperMock = searchHelper as MockedFunction<typeof searchHelper>;
-
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-function setup() {
-  const http = new Http('token');
-  const search = new SearchApi();
-
-  return { http, search };
-}
+const searchOptions = {
+  limit: 1,
+  offset: 2,
+  market: 'bar',
+  include_external: 'audio',
+} as const;
 
 describe('SearchApi', () => {
-  beforeEach(() => {
+  afterEach(() => {
     vi.resetAllMocks();
   });
 
   describe('search', () => {
+    let searchSpy: SpyInstance;
     beforeEach(() => {
-      searchHelperMock.mockResolvedValue(searchFixture);
+      searchSpy = vi
+        .spyOn(SearchService, 'search')
+        .mockResolvedValue(searchFixture);
     });
 
-    it.todo('should search for an item (without options)', async () => {
-      const { http, search } = setup();
-
+    it('should search for an item (without options)', async () => {
       const response = await search.search('foo', ['album', 'artist']);
 
       expect(response).toEqual(searchFixture);
-      expect(searchHelperMock).toHaveBeenCalledWith(
-        http,
+      expect(searchSpy).toHaveBeenCalledWith(
         'foo',
         ['album', 'artist'],
+        undefined,
+        undefined,
+        undefined,
         undefined,
       );
     });
 
-    it.todo('should search for an item (with options)', async () => {
-      const { http, search } = setup();
-
-      const response = await search.search('foo', ['album', 'artist'], {
-        limit: 2,
-      });
-
-      expect(response).toEqual(searchFixture);
-      expect(searchHelperMock).toHaveBeenCalledWith(
-        http,
+    it('should search for an item (with options)', async () => {
+      const response = await search.search(
         'foo',
         ['album', 'artist'],
-        { limit: 2 },
+        searchOptions,
+      );
+
+      expect(response).toEqual(searchFixture);
+      expect(searchSpy).toHaveBeenCalledWith(
+        'foo',
+        ['album', 'artist'],
+        'bar',
+        1,
+        2,
+        'audio',
       );
     });
   });
 
   describe('searchAlbums', () => {
+    let searchAlbumsSpy: SpyInstance;
     beforeEach(() => {
-      searchHelperMock.mockResolvedValue(searchAlbumsFixture);
+      searchAlbumsSpy = vi
+        .spyOn(SearchService, 'search')
+        .mockResolvedValue(searchAlbumsFixture);
     });
 
-    it.todo('should search for an album (without options)', async () => {
-      const { http, search } = setup();
-
+    it('should search for an album (without options)', async () => {
       const response = await search.searchAlbums('foo');
 
       expect(response).toEqual(searchAlbumsFixture.albums);
-      expect(searchHelperMock).toHaveBeenCalledWith(
-        http,
+      expect(searchAlbumsSpy).toHaveBeenCalledWith(
         'foo',
         ['album'],
+        undefined,
+        undefined,
+        undefined,
         undefined,
       );
     });
 
-    it.todo('should search for an album (with options)', async () => {
-      const { http, search } = setup();
-
-      const response = await search.searchAlbums('foo', { limit: 2 });
+    it('should search for an album (with options)', async () => {
+      const response = await search.searchAlbums('foo', searchOptions);
 
       expect(response).toEqual(searchAlbumsFixture.albums);
-      expect(searchHelperMock).toHaveBeenCalledWith(http, 'foo', ['album'], {
-        limit: 2,
-      });
+      expect(searchAlbumsSpy).toHaveBeenCalledWith(
+        'foo',
+        ['album'],
+        'bar',
+        1,
+        2,
+        'audio',
+      );
     });
   });
 
   describe('searchArtists', () => {
+    let searchArtistsSpy: SpyInstance;
     beforeEach(() => {
-      searchHelperMock.mockResolvedValue(searchArtistsFixture);
+      searchArtistsSpy = vi
+        .spyOn(SearchService, 'search')
+        .mockResolvedValue(searchArtistsFixture);
     });
 
-    it.todo('should search for an artist (without options)', async () => {
-      const { http, search } = setup();
-
+    it('should search for an artist (without options)', async () => {
       const response = await search.searchArtists('foo');
 
       expect(response).toEqual(searchArtistsFixture.artists);
-      expect(searchHelperMock).toHaveBeenCalledWith(
-        http,
+      expect(searchArtistsSpy).toHaveBeenCalledWith(
         'foo',
         ['artist'],
+        undefined,
+        undefined,
+        undefined,
         undefined,
       );
     });
 
-    it.todo('should search for an artist (with options)', async () => {
-      const { http, search } = setup();
-
-      const response = await search.searchArtists('foo', { limit: 2 });
+    it('should search for an artist (with options)', async () => {
+      const response = await search.searchArtists('foo', searchOptions);
 
       expect(response).toEqual(searchArtistsFixture.artists);
-      expect(searchHelperMock).toHaveBeenCalledWith(http, 'foo', ['artist'], {
-        limit: 2,
-      });
+      expect(searchArtistsSpy).toHaveBeenCalledWith(
+        'foo',
+        ['artist'],
+        'bar',
+        1,
+        2,
+        'audio',
+      );
+    });
+  });
+
+  describe('searchAudiobooks', () => {
+    let searchAudiobooksSpy: SpyInstance;
+    beforeEach(() => {
+      searchAudiobooksSpy = vi
+        .spyOn(SearchService, 'search')
+        .mockResolvedValue(searchAudiobooksFixture);
+    });
+
+    it('should search for an audiobook (without options)', async () => {
+      const response = await search.searchAudiobooks('foo');
+
+      expect(response).toEqual(searchAudiobooksFixture.audiobooks);
+      expect(searchAudiobooksSpy).toHaveBeenCalledWith(
+        'foo',
+        ['audiobook'],
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+      );
+    });
+
+    it('should search for an audiobook (with options)', async () => {
+      const response = await search.searchAudiobooks('foo', searchOptions);
+
+      expect(response).toEqual(searchAudiobooksFixture.audiobooks);
+      expect(searchAudiobooksSpy).toHaveBeenCalledWith(
+        'foo',
+        ['audiobook'],
+        'bar',
+        1,
+        2,
+        'audio',
+      );
     });
   });
 
   describe('searchEpisodes', () => {
+    let searchEpisodesSpy: SpyInstance;
     beforeEach(() => {
-      searchHelperMock.mockResolvedValue(searchEpisodesFixture);
+      searchEpisodesSpy = vi
+        .spyOn(SearchService, 'search')
+        .mockResolvedValue(searchEpisodesFixture);
     });
 
-    it.todo('should search for an episode (without options)', async () => {
-      const { http, search } = setup();
-
+    it('should search for an episode (without options)', async () => {
       const response = await search.searchEpisodes('foo');
 
       expect(response).toEqual(searchEpisodesFixture.episodes);
-      expect(searchHelperMock).toHaveBeenCalledWith(
-        http,
+      expect(searchEpisodesSpy).toHaveBeenCalledWith(
         'foo',
         ['episode'],
+        undefined,
+        undefined,
+        undefined,
         undefined,
       );
     });
 
-    it.todo('should search for an episode (with options)', async () => {
-      const { http, search } = setup();
-
-      const response = await search.searchEpisodes('foo', { limit: 2 });
+    it('should search for an episode (with options)', async () => {
+      const response = await search.searchEpisodes('foo', searchOptions);
 
       expect(response).toEqual(searchEpisodesFixture.episodes);
-      expect(searchHelperMock).toHaveBeenCalledWith(http, 'foo', ['episode'], {
-        limit: 2,
-      });
+      expect(searchEpisodesSpy).toHaveBeenCalledWith(
+        'foo',
+        ['episode'],
+        'bar',
+        1,
+        2,
+        'audio',
+      );
     });
   });
 
   describe('searchPlaylists', () => {
+    let searchPlaylistsSpy: SpyInstance;
     beforeEach(() => {
-      searchHelperMock.mockResolvedValue(searchPlaylistsFixture);
+      searchPlaylistsSpy = vi
+        .spyOn(SearchService, 'search')
+        .mockResolvedValue(searchPlaylistsFixture);
     });
 
-    it.todo('should search for a playlist (without options)', async () => {
-      const { http, search } = setup();
-
+    it('should search for a playlist (without options)', async () => {
       const response = await search.searchPlaylists('foo');
 
       expect(response).toEqual(searchPlaylistsFixture.playlists);
-      expect(searchHelperMock).toHaveBeenCalledWith(
-        http,
+      expect(searchPlaylistsSpy).toHaveBeenCalledWith(
         'foo',
         ['playlist'],
+        undefined,
+        undefined,
+        undefined,
         undefined,
       );
     });
 
-    it.todo('should search for a playlist (with options)', async () => {
-      const { http, search } = setup();
-
-      const response = await search.searchPlaylists('foo', { limit: 2 });
+    it('should search for a playlist (with options)', async () => {
+      const response = await search.searchPlaylists('foo', searchOptions);
 
       expect(response).toEqual(searchPlaylistsFixture.playlists);
-      expect(searchHelperMock).toHaveBeenCalledWith(http, 'foo', ['playlist'], {
-        limit: 2,
-      });
+      expect(searchPlaylistsSpy).toHaveBeenCalledWith(
+        'foo',
+        ['playlist'],
+        'bar',
+        1,
+        2,
+        'audio',
+      );
     });
   });
 
   describe('searchShows', () => {
+    let searchShowsSpy: SpyInstance;
     beforeEach(() => {
-      searchHelperMock.mockResolvedValue(searchShowsFixture);
+      searchShowsSpy = vi
+        .spyOn(SearchService, 'search')
+        .mockResolvedValue(searchShowsFixture);
     });
 
-    it.todo('should search for a show (without options)', async () => {
-      const { http, search } = setup();
-
+    it('should search for a show (without options)', async () => {
       const response = await search.searchShows('foo');
 
       expect(response).toEqual(searchShowsFixture.shows);
-      expect(searchHelperMock).toHaveBeenCalledWith(
-        http,
+      expect(searchShowsSpy).toHaveBeenCalledWith(
         'foo',
         ['show'],
+        undefined,
+        undefined,
+        undefined,
         undefined,
       );
     });
 
-    it.todo('should search for a show (with options)', async () => {
-      const { http, search } = setup();
-
-      const response = await search.searchShows('foo', { limit: 2 });
+    it('should search for a show (with options)', async () => {
+      const response = await search.searchShows('foo', searchOptions);
 
       expect(response).toEqual(searchShowsFixture.shows);
-      expect(searchHelperMock).toHaveBeenCalledWith(http, 'foo', ['show'], {
-        limit: 2,
-      });
+      expect(searchShowsSpy).toHaveBeenCalledWith(
+        'foo',
+        ['show'],
+        'bar',
+        1,
+        2,
+        'audio',
+      );
     });
   });
 
   describe('searchTracks', () => {
+    let searchTracksSpy: SpyInstance;
     beforeEach(() => {
-      searchHelperMock.mockResolvedValue(searchTracksFixture);
+      searchTracksSpy = vi
+        .spyOn(SearchService, 'search')
+        .mockResolvedValue(searchTracksFixture);
     });
 
-    it.todo('should search for a track (without options)', async () => {
-      const { http, search } = setup();
-
+    it('should search for a track (without options)', async () => {
       const response = await search.searchTracks('foo');
 
       expect(response).toEqual(searchTracksFixture.tracks);
-      expect(searchHelperMock).toHaveBeenCalledWith(
-        http,
+      expect(searchTracksSpy).toHaveBeenCalledWith(
         'foo',
         ['track'],
+        undefined,
+        undefined,
+        undefined,
         undefined,
       );
     });
 
-    it.todo('should search for a track (with options)', async () => {
-      const { http, search } = setup();
-
-      const response = await search.searchTracks('foo', { limit: 2 });
+    it('should search for a track (with options)', async () => {
+      const response = await search.searchTracks('foo', searchOptions);
 
       expect(response).toEqual(searchTracksFixture.tracks);
-      expect(searchHelperMock).toHaveBeenCalledWith(http, 'foo', ['track'], {
-        limit: 2,
-      });
+      expect(searchTracksSpy).toHaveBeenCalledWith(
+        'foo',
+        ['track'],
+        'bar',
+        1,
+        2,
+        'audio',
+      );
     });
   });
 });

--- a/src/apis/ShowsApi.test.ts
+++ b/src/apis/ShowsApi.test.ts
@@ -1,120 +1,96 @@
-import { type MockedClass } from 'vitest';
+import { type SpyInstance } from 'vitest';
 
 import {
   getShowEpisodesFixture,
   getShowsFixture,
   showFixture,
 } from '../fixtures';
-import { Http } from '../helpers/Http';
+import { ShowsService } from '../openapi/services/ShowsService';
 
 import { ShowsApi } from './ShowsApi';
 
-vi.mock('../helpers/Http');
-
-const HttpMock = Http as MockedClass<typeof Http>;
-
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-function setup() {
-  const httpMock = new HttpMock('token');
-  const shows = new ShowsApi();
-
-  return { httpMock, shows };
-}
+const shows = new ShowsApi();
 
 describe('ShowsApi', () => {
-  beforeEach(() => {
+  afterEach(() => {
     vi.resetAllMocks();
   });
 
   describe('getShow', () => {
+    let getShowSpy: SpyInstance;
     beforeEach(() => {
-      HttpMock.prototype.get.mockResolvedValue(showFixture);
+      getShowSpy = vi
+        .spyOn(ShowsService, 'getAShow')
+        .mockResolvedValue(showFixture);
     });
 
-    it.todo('should get a show (without options)', async () => {
-      const { httpMock, shows } = setup();
-
+    it('should get a show (without options)', async () => {
       const response = await shows.getShow('foo');
 
       expect(response).toEqual(showFixture);
-      expect(httpMock.get).toHaveBeenCalledWith('/shows/foo', undefined);
+      expect(getShowSpy).toHaveBeenCalledWith('foo', undefined);
     });
 
-    it.todo('should get a show (with options)', async () => {
-      const { httpMock, shows } = setup();
-
+    it('should get a show (with options)', async () => {
       const response = await shows.getShow('foo', { market: 'bar' });
 
       expect(response).toEqual(showFixture);
-      expect(httpMock.get).toHaveBeenCalledWith('/shows/foo', {
-        params: {
-          market: 'bar',
-        },
-      });
+      expect(getShowSpy).toHaveBeenCalledWith('foo', 'bar');
     });
   });
 
   describe('getShowEpisodes', () => {
+    let getShowEpisodesSpy: SpyInstance;
     beforeEach(() => {
-      HttpMock.prototype.get.mockResolvedValue(getShowEpisodesFixture);
+      getShowEpisodesSpy = vi
+        .spyOn(ShowsService, 'getAShowsEpisodes')
+        .mockResolvedValue(getShowEpisodesFixture);
     });
 
-    it.todo("should get a show's episodes (without options)", async () => {
-      const { httpMock, shows } = setup();
-
+    it("should get a show's episodes (without options)", async () => {
       const response = await shows.getShowEpisodes('foo');
 
       expect(response).toEqual(getShowEpisodesFixture);
-      expect(httpMock.get).toHaveBeenCalledWith(
-        '/shows/foo/episodes',
+      expect(getShowEpisodesSpy).toHaveBeenCalledWith(
+        'foo',
+        undefined,
+        undefined,
         undefined,
       );
     });
 
-    it.todo("should get a show's episodes (with options)", async () => {
-      const { httpMock, shows } = setup();
-
-      const response = await shows.getShowEpisodes('foo', { limit: 2 });
+    it("should get a show's episodes (with options)", async () => {
+      const response = await shows.getShowEpisodes('foo', {
+        limit: 1,
+        offset: 2,
+        market: 'bar',
+      });
 
       expect(response).toEqual(getShowEpisodesFixture);
-      expect(httpMock.get).toHaveBeenCalledWith('/shows/foo/episodes', {
-        params: {
-          limit: 2,
-        },
-      });
+      expect(getShowEpisodesSpy).toHaveBeenCalledWith('foo', 'bar', 1, 2);
     });
   });
 
   describe('getShows', () => {
+    let getShowsSpy: SpyInstance;
     beforeEach(() => {
-      HttpMock.prototype.get.mockResolvedValue(getShowsFixture);
+      getShowsSpy = vi
+        .spyOn(ShowsService, 'getMultipleShows')
+        .mockResolvedValue(getShowsFixture);
     });
 
-    it.todo('should get several shows (without options)', async () => {
-      const { httpMock, shows } = setup();
-
+    it('should get several shows (without options)', async () => {
       const response = await shows.getShows(['foo', 'bar']);
 
       expect(response).toEqual(getShowsFixture.shows);
-      expect(httpMock.get).toHaveBeenCalledWith('/shows', {
-        params: {
-          ids: ['foo', 'bar'],
-        },
-      });
+      expect(getShowsSpy).toHaveBeenCalledWith('foo,bar', undefined);
     });
 
-    it.todo('should get several shows (with options)', async () => {
-      const { httpMock, shows } = setup();
-
+    it('should get several shows (with options)', async () => {
       const response = await shows.getShows(['foo', 'bar'], { market: 'baz' });
 
       expect(response).toEqual(getShowsFixture.shows);
-      expect(httpMock.get).toHaveBeenCalledWith('/shows', {
-        params: {
-          ids: ['foo', 'bar'],
-          market: 'baz',
-        },
-      });
+      expect(getShowsSpy).toHaveBeenCalledWith('foo,bar', 'baz');
     });
   });
 });

--- a/src/apis/TracksApi.test.ts
+++ b/src/apis/TracksApi.test.ts
@@ -1,4 +1,4 @@
-import { type MockedClass } from 'vitest';
+import { type SpyInstance } from 'vitest';
 
 import {
   audioAnalysisFixture,
@@ -7,138 +7,98 @@ import {
   getTracksFixture,
   trackFixture,
 } from '../fixtures';
-import { Http } from '../helpers/Http';
+import { TracksService } from '../openapi/services/TracksService';
 
 import { TracksApi } from './TracksApi';
 
-vi.mock('../helpers/Http');
-
-const HttpMock = Http as MockedClass<typeof Http>;
-
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-function setup() {
-  const httpMock = new HttpMock('token');
-  const tracks = new TracksApi();
-
-  return { httpMock, tracks };
-}
+const tracks = new TracksApi();
 
 describe('TracksApi', () => {
-  beforeEach(() => {
+  afterEach(() => {
     vi.resetAllMocks();
   });
 
   describe('getAudioAnalysisForTrack', () => {
-    beforeEach(() => {
-      HttpMock.prototype.get.mockResolvedValue(audioAnalysisFixture);
-    });
-
-    it.todo('should get audio analysis for a track', async () => {
-      const { httpMock, tracks } = setup();
-
+    it('should get audio analysis for a track', async () => {
+      const getAudioAnalysisForTrackSpy = vi
+        .spyOn(TracksService, 'getAudioAnalysis')
+        .mockResolvedValue(audioAnalysisFixture);
       const response = await tracks.getAudioAnalysisForTrack('foo');
 
       expect(response).toEqual(audioAnalysisFixture);
-      expect(httpMock.get).toHaveBeenCalledWith('/audio-analysis/foo');
+      expect(getAudioAnalysisForTrackSpy).toHaveBeenCalledWith('foo');
     });
   });
 
   describe('getAudioFeaturesForTrack', () => {
-    beforeEach(() => {
-      HttpMock.prototype.get.mockResolvedValue(audioFeaturesFixture);
-    });
-
-    it.todo('should get audio features for a track', async () => {
-      const { httpMock, tracks } = setup();
-
+    it('should get audio features for a track', async () => {
+      const getAudioFeaturesForTrackSpy = vi
+        .spyOn(TracksService, 'getAudioFeatures')
+        .mockResolvedValue(audioFeaturesFixture);
       const response = await tracks.getAudioFeaturesForTrack('foo');
 
       expect(response).toEqual(audioFeaturesFixture);
-      expect(httpMock.get).toHaveBeenCalledWith('/audio-features/foo');
+      expect(getAudioFeaturesForTrackSpy).toHaveBeenCalledWith('foo');
     });
   });
 
   describe('getAudioFeaturesForTracks', () => {
-    beforeEach(() => {
-      HttpMock.prototype.get.mockResolvedValue(
-        getAudioFeaturesForTracksFixture,
-      );
-    });
-
-    it.todo('should get audio features for several tracks', async () => {
-      const { httpMock, tracks } = setup();
-
+    it('should get audio features for several tracks', async () => {
+      const getAudioFeaturesForTracksSpy = vi
+        .spyOn(TracksService, 'getSeveralAudioFeatures')
+        .mockResolvedValue(getAudioFeaturesForTracksFixture);
       const response = await tracks.getAudioFeaturesForTracks(['foo', 'bar']);
 
       expect(response).toEqual(getAudioFeaturesForTracksFixture.audio_features);
-      expect(httpMock.get).toHaveBeenCalledWith('/audio-features', {
-        params: {
-          ids: ['foo', 'bar'],
-        },
-      });
+      expect(getAudioFeaturesForTracksSpy).toHaveBeenCalledWith('foo,bar');
     });
   });
 
   describe('getTrack', () => {
+    let getTrackSpy: SpyInstance;
     beforeEach(() => {
-      HttpMock.prototype.get.mockResolvedValue(trackFixture);
+      getTrackSpy = vi
+        .spyOn(TracksService, 'getTrack')
+        .mockResolvedValue(trackFixture);
     });
 
-    it.todo('should get a track (without options)', async () => {
-      const { httpMock, tracks } = setup();
-
+    it('should get a track (without options)', async () => {
       const response = await tracks.getTrack('foo');
 
       expect(response).toEqual(trackFixture);
-      expect(httpMock.get).toHaveBeenCalledWith('/tracks/foo', undefined);
+      expect(getTrackSpy).toHaveBeenCalledWith('foo', undefined);
     });
 
-    it.todo('should get a track (with options)', async () => {
-      const { httpMock, tracks } = setup();
-
+    it('should get a track (with options)', async () => {
       const response = await tracks.getTrack('foo', { market: 'bar' });
 
       expect(response).toEqual(trackFixture);
-      expect(httpMock.get).toHaveBeenCalledWith('/tracks/foo', {
-        params: {
-          market: 'bar',
-        },
-      });
+      expect(getTrackSpy).toHaveBeenCalledWith('foo', 'bar');
     });
   });
 
   describe('getTracks', () => {
+    let getTracksSpy: SpyInstance;
     beforeEach(() => {
-      HttpMock.prototype.get.mockResolvedValue(getTracksFixture);
+      getTracksSpy = vi
+        .spyOn(TracksService, 'getSeveralTracks')
+        .mockResolvedValue(getTracksFixture);
     });
 
-    it.todo('should get several tracks (without options)', async () => {
-      const { httpMock, tracks } = setup();
-
+    it('should get several tracks (without options)', async () => {
       const response = await tracks.getTracks(['foo', 'bar']);
 
       expect(response).toEqual(getTracksFixture.tracks);
-      expect(httpMock.get).toHaveBeenCalledWith('/tracks', {
-        params: {
-          ids: ['foo', 'bar'],
-        },
-      });
+      expect(getTracksSpy).toHaveBeenCalledWith('foo,bar', undefined);
     });
 
-    it.todo('should get several tracks (with options)', async () => {
-      const { httpMock, tracks } = setup();
-
+    it('should get several tracks (with options)', async () => {
       const response = await tracks.getTracks(['foo', 'bar'], {
         market: 'baz',
       });
 
       expect(response).toEqual(getTracksFixture.tracks);
-      expect(httpMock.get).toHaveBeenCalledWith('/tracks', {
-        params: {
-          ids: ['foo', 'bar'],
-          market: 'baz',
-        },
-      });
+      expect(getTracksSpy).toHaveBeenCalledWith('foo,bar', 'baz');
     });
   });
 });

--- a/src/apis/TracksApi.ts
+++ b/src/apis/TracksApi.ts
@@ -79,8 +79,9 @@ export class TracksApi {
     trackIds: string[],
     options?: MarketOptions,
   ): Promise<TrackObject[]> {
-    return await TracksService.getSeveralTracks(trackIds.join(',')).then(
-      ({ tracks }) => tracks,
-    );
+    return await TracksService.getSeveralTracks(
+      trackIds.join(','),
+      options?.market,
+    ).then(({ tracks }) => tracks);
   }
 }

--- a/src/apis/UsersApi.test.ts
+++ b/src/apis/UsersApi.test.ts
@@ -1,54 +1,36 @@
-import { type MockedClass } from 'vitest';
-
 import { privateUserFixture, publicUserFixture } from '../fixtures';
-import { Http } from '../helpers/Http';
+import { UsersService } from '../openapi/services/UsersService';
 
 import { UsersApi } from './UsersApi';
 
-vi.mock('../helpers/Http');
-
-const HttpMock = Http as MockedClass<typeof Http>;
-
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-function setup() {
-  const httpMock = new HttpMock('token');
-  const users = new UsersApi();
-
-  return { httpMock, users };
-}
+const users = new UsersApi();
 
 describe(UsersApi.name, () => {
-  beforeEach(() => {
+  afterEach(() => {
     vi.resetAllMocks();
   });
 
   describe('getMe', () => {
-    beforeEach(() => {
-      HttpMock.prototype.get.mockResolvedValue(privateUserFixture);
-    });
-
-    it.todo("should get the current user's profile", async () => {
-      const { httpMock, users } = setup();
-
+    it("should get the current user's profile", async () => {
+      const getMeSpy = vi
+        .spyOn(UsersService, 'getCurrentUsersProfile')
+        .mockResolvedValue(privateUserFixture);
       const response = await users.getMe();
 
       expect(response).toEqual(privateUserFixture);
-      expect(httpMock.get).toHaveBeenCalledWith('/me');
+      expect(getMeSpy).toHaveBeenCalledWith();
     });
   });
 
   describe('getUser', () => {
-    beforeEach(() => {
-      HttpMock.prototype.get.mockResolvedValue(publicUserFixture);
-    });
-
-    it.todo("should get a user's profile", async () => {
-      const { httpMock, users } = setup();
-
+    it("should get a user's profile", async () => {
+      const getUserSpy = vi
+        .spyOn(UsersService, 'getUsersProfile')
+        .mockResolvedValue(publicUserFixture);
       const response = await users.getUser('foo');
 
       expect(response).toEqual(publicUserFixture);
-      expect(httpMock.get).toHaveBeenCalledWith('/users/foo');
+      expect(getUserSpy).toHaveBeenCalledWith('foo');
     });
   });
 });

--- a/src/fixtures/index.ts
+++ b/src/fixtures/index.ts
@@ -32,6 +32,7 @@ export * from './browse';
 export * from './episodes';
 export * from './follow';
 export * from './library';
+export * from './markets';
 export * from './personalization';
 export * from './player';
 export * from './playlists';

--- a/src/fixtures/personalization/getMyTopTracksFixture.ts
+++ b/src/fixtures/personalization/getMyTopTracksFixture.ts
@@ -1,13 +1,10 @@
-import {
-  type PagingSimplifiedTrackObject,
-  type SimplifiedTrackObject,
-} from '../../openapi';
+import { type PagingTrackObject, type TrackObject } from '../../openapi';
 
-export const getMyTopTracksFixture: PagingSimplifiedTrackObject = {
+export const getMyTopTracksFixture: PagingTrackObject = {
   items: [
     {
       album: {
-        album_type: 'ALBUM',
+        album_type: 'album',
         artists: [
           {
             external_urls: {
@@ -240,7 +237,7 @@ export const getMyTopTracksFixture: PagingSimplifiedTrackObject = {
       track_number: 10,
       type: 'track',
       uri: 'spotify:track:0M0bBnanRqRGKs8pz7ZWi0',
-    } as SimplifiedTrackObject,
+    } as TrackObject,
   ],
   total: 50,
   limit: 1,

--- a/src/fixtures/player/getMyDevicesFixture.ts
+++ b/src/fixtures/player/getMyDevicesFixture.ts
@@ -1,0 +1,15 @@
+import { type DeviceObject } from '../../openapi';
+
+export const getMyDevicesFixture: { devices: DeviceObject[] } = {
+  devices: [
+    {
+      id: 'string',
+      is_active: false,
+      is_private_session: false,
+      is_restricted: false,
+      name: 'Kitchen speaker',
+      type: 'computer',
+      volume_percent: 59,
+    },
+  ],
+};

--- a/src/fixtures/player/index.ts
+++ b/src/fixtures/player/index.ts
@@ -1,2 +1,3 @@
+export { getMyDevicesFixture } from './getMyDevicesFixture';
 export { getRecentlyPlayedTracksFixture } from './getRecentlyPlayedTracksFixture';
 export { getQueueFixture } from './getQueueFixture';

--- a/src/types/SpotifyOptions.ts
+++ b/src/types/SpotifyOptions.ts
@@ -125,11 +125,11 @@ export interface PersonalizationOptions extends PagingOptions {
 // +--------+
 
 export interface GetCurrentlyPlayingTrackOptions extends MarketOptions {
-  additional_types?: Array<'episode'>;
+  additional_types?: ['episode'];
 }
 
 export interface GetPlaybackInfoOptions extends MarketOptions {
-  additional_types?: Array<'episode'>;
+  additional_types?: ['episode'];
 }
 
 export interface GetRecentlyPlayedTracksOptions {
@@ -163,12 +163,12 @@ export interface CreatePlaylistOptions {
 }
 
 export interface GetPlaylistOptions extends MarketOptions {
-  additional_types?: Array<'episode'>;
+  additional_types?: ['episode'];
   fields?: string;
 }
 
 export interface GetPlaylistItemsOptions extends PagingMarketOptions {
-  additional_types?: Array<'episode'>;
+  additional_types?: ['episode'];
   fields?: string;
 }
 


### PR DESCRIPTION
### Summary
Updates tests to use new FooServices in respective FooApi file

### Changes
- Restored all tests that were previously disabled
- Added new test suites for AudiobooksApi, MarketsApi
- Added new tests for audiobooks, episodes in LibraryApi
- Added tests for misc new endpoints
- Added  getMyDevicesFixture